### PR TITLE
fix: align dialog padding for header contents and footer

### DIFF
--- a/packages/basic-dialog/src/dialog.js
+++ b/packages/basic-dialog/src/dialog.js
@@ -23,8 +23,8 @@ const BasicDialog = (props) => {
             <DialogTitle className={classes.titleContainer} disableTypography>
                 <Typography variant='h5'>{props.title}</Typography>
             </DialogTitle>
-            <DialogContent>{props.children || ''}</DialogContent>
-            <DialogActions>{props.actionButtons}</DialogActions>
+            <DialogContent className={classes.contentContainer}>{props.children || ''}</DialogContent>
+            <DialogActions className={classes.footerContainer}>{props.actionButtons}</DialogActions>
         </Dialog>
     );
 };

--- a/packages/basic-dialog/src/styles.js
+++ b/packages/basic-dialog/src/styles.js
@@ -4,11 +4,17 @@ const useStyles = makeStyles((theme) => ({
     container: {
         minWidth: '50%',
     },
+    contentContainer: {
+        padding: `0 ${theme.spacing(4)}px`,
+    },
     titleContainer: {
         alignItems: 'center',
         display: 'flex',
         justifyContent: 'space-between',
-        padding: theme.spacing(2),
+        padding: theme.spacing(4),
+    },
+    footerContainer: {
+        padding: theme.spacing(4),
     },
 }));
 


### PR DESCRIPTION
## Description
### Fix (styling)
Align dialog padding for header, content and footer

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] The test workflow is passing locally

## Screenshots/GIFs
### Full Screen
<img width="1461" alt="Screen Shot 2020-07-08 at 8 21 34 PM" src="https://user-images.githubusercontent.com/54541871/86986344-13672b80-c159-11ea-9cf8-40edc2e5a6ad.png">

### Mobile
<img width="433" alt="Screen Shot 2020-07-08 at 8 21 52 PM" src="https://user-images.githubusercontent.com/54541871/86986335-0e09e100-c159-11ea-83c0-01d8d3d4552e.png">
