### PR TITLE
fix: spread other props down, only show helper text on error

### DIFF
--- a/packages/number-field/src/number-field.js
+++ b/packages/number-field/src/number-field.js
@@ -17,17 +17,19 @@ const NumberField = (props) => {
         onChange,
         value,
         variant,
+        ...other
     } = props;
 
     return (
         <NumberFormat
+            {...other}
             autoFocus={autoFocus}
             className={className}
             customInput={TextField}
             error={error}
             format={format}
             fullWidth={fullWidth}
-            helperText={helperText}
+            helperText={error ? helperText : ''}
             id='formatted-numberformat-input'
             InputProps={{ 'data-testid': 'number-field-input' }}
             key='user-modal-phone-number-input'

--- a/stories/utilities/props/number-field.md
+++ b/stories/utilities/props/number-field.md
@@ -7,7 +7,7 @@
 | error      | no       | bool used to display helper text                                               |
 | format     | no       | string to format numbers (example `(###) ###-#####)`                           |
 | fullWidth  | no       | bool for Material UI text field width styling (defaults to `true`)             |
-| helperText | yes      | string for error label                                                         |
+| helperText | yes      | string for error label (only displayed on `error={true}`)                      |
 | label      | yes      | number or string for label of the input element                                |
 | margin     | no       | string for Material UI text field margin styling (defaults to `dense`)         |
 | onChange   | yes      | function to call when input is received                                        |

--- a/test/number-field/number-field.spec.js
+++ b/test/number-field/number-field.spec.js
@@ -33,6 +33,7 @@ describe('Number Field', () => {
         //when
         render(
             <NumberField
+                error={true}
                 helperText={mockData.errorText}
                 format='(###) ###-####'
                 label='Phone Number'
@@ -44,5 +45,27 @@ describe('Number Field', () => {
 
         //then
         expect(screen.getByText(mockData.errorText)).toBeVisible();
+    });
+
+    it('should not show helper text if no error', () => {
+        //given
+        const mockData = {
+            errorText: chance.word(),
+        };
+
+        //when
+        render(
+            <NumberField
+                helperText={mockData.errorText}
+                format='(###) ###-####'
+                label='Phone Number'
+                name='phoneNumber'
+                onChange={() => {}}
+                value=''
+            />
+        );
+
+        //then
+        expect(screen.queryByText(mockData.errorText)).toBeNull();
     });
 });


### PR DESCRIPTION
## Description

Only display helper text on error. Pass all other props down to TextField for styling.