### PR TITLE
feat: allow select to take required, error and helper text

### DIFF
--- a/packages/select/src/select.js
+++ b/packages/select/src/select.js
@@ -7,7 +7,7 @@ import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 
 const Select = (props) => {
-    const { color, darkMode, label, options, renderOption, selectedOption, ...otherProps } = props;
+    const { color, darkMode, label, options, renderOption, required, selectedOption, ...otherProps } = props;
     const classes = useStyles(darkMode)();
     const textFieldClasses = useTextFieldStyles(darkMode)();
 
@@ -37,6 +37,7 @@ const Select = (props) => {
                     variant='outlined'
                     label={label}
                     fullWidth
+                    required={required}
                 />
             )}
             renderOption={renderOption}
@@ -50,6 +51,7 @@ Select.defaultProps = {
     color: null,
     darkMode: false,
     renderOption: (option) => <Typography noWrap>{option}</Typography>,
+    required: false,
 };
 
 Select.propTypes = {
@@ -58,6 +60,7 @@ Select.propTypes = {
     label: PropTypes.string.isRequired,
     options: PropTypes.array.isRequired,
     renderOption: PropTypes.func,
+    required: PropTypes.bool,
     selectedOption: PropTypes.any,
 };
 

--- a/packages/select/src/select.js
+++ b/packages/select/src/select.js
@@ -7,7 +7,18 @@ import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 
 const Select = (props) => {
-    const { color, darkMode, label, options, renderOption, required, selectedOption, ...otherProps } = props;
+    const {
+        color,
+        darkMode,
+        error,
+        helperText,
+        label,
+        options,
+        renderOption,
+        required,
+        selectedOption,
+        ...otherProps
+    } = props;
     const classes = useStyles(darkMode)();
     const textFieldClasses = useTextFieldStyles(darkMode)();
 
@@ -26,6 +37,8 @@ const Select = (props) => {
                     {...params}
                     className={textFieldClasses.input}
                     color={color}
+                    error={error}
+                    helperText={helperText}
                     InputProps={{
                         ...params.InputProps,
                         classes: {
@@ -50,6 +63,8 @@ const Select = (props) => {
 Select.defaultProps = {
     color: null,
     darkMode: false,
+    error: false,
+    helperText: '',
     renderOption: (option) => <Typography noWrap>{option}</Typography>,
     required: false,
 };
@@ -57,6 +72,8 @@ Select.defaultProps = {
 Select.propTypes = {
     color: PropTypes.string,
     darkMode: PropTypes.bool,
+    error: PropTypes.bool,
+    helperText: PropTypes.string,
     label: PropTypes.string.isRequired,
     options: PropTypes.array.isRequired,
     renderOption: PropTypes.func,

--- a/stories/select/with-error.stories.js
+++ b/stories/select/with-error.stories.js
@@ -1,0 +1,51 @@
+import Select from '../../packages/select/src';
+import React from 'react';
+import propsMarkdown from '../utilities/props/select.md';
+import { makeStyles } from '@material-ui/core/styles';
+import { storiesOf } from '@storybook/react';
+
+const useStyles = makeStyles({
+    container: {
+        padding: 20,
+    },
+});
+
+storiesOf('Select', module).add(
+    'With error',
+    () => {
+        const classes = useStyles();
+        const [value, setValue] = React.useState('');
+
+        let options = [];
+
+        let i = 0;
+        while (i < 10000) {
+            options.push(`${i}`);
+            i++;
+        }
+
+        const onChange = (event, value) => {
+            if (value) {
+                setValue(value);
+            } else {
+                setValue('');
+            }
+        };
+
+        return (
+            <div className={classes.container}>
+                <Select
+                    error
+                    label='Virtualized Select'
+                    onChange={onChange}
+                    options={options}
+                    required
+                    selectedOption={value}
+                />
+            </div>
+        );
+    },
+    {
+        notes: { markdown: propsMarkdown },
+    }
+);

--- a/stories/select/with-helper-text.stories.js
+++ b/stories/select/with-helper-text.stories.js
@@ -1,0 +1,51 @@
+import Select from '../../packages/select/src';
+import React from 'react';
+import propsMarkdown from '../utilities/props/select.md';
+import { makeStyles } from '@material-ui/core/styles';
+import { storiesOf } from '@storybook/react';
+
+const useStyles = makeStyles({
+    container: {
+        padding: 20,
+    },
+});
+
+storiesOf('Select', module).add(
+    'With helper text',
+    () => {
+        const classes = useStyles();
+        const [value, setValue] = React.useState('');
+
+        let options = [];
+
+        let i = 0;
+        while (i < 10000) {
+            options.push(`${i}`);
+            i++;
+        }
+
+        const onChange = (event, value) => {
+            if (value) {
+                setValue(value);
+            } else {
+                setValue('');
+            }
+        };
+
+        return (
+            <div className={classes.container}>
+                <Select
+                    helperText='Select something from above'
+                    label='Virtualized Select'
+                    onChange={onChange}
+                    options={options}
+                    required
+                    selectedOption={value}
+                />
+            </div>
+        );
+    },
+    {
+        notes: { markdown: propsMarkdown },
+    }
+);

--- a/stories/select/with-required.stories.js
+++ b/stories/select/with-required.stories.js
@@ -1,0 +1,50 @@
+import Select from '../../packages/select/src';
+import React from 'react';
+import propsMarkdown from '../utilities/props/select.md';
+import { makeStyles } from '@material-ui/core/styles';
+import { storiesOf } from '@storybook/react';
+
+const useStyles = makeStyles({
+    container: {
+        padding: 20,
+    },
+});
+
+storiesOf('Select', module).add(
+    'With required',
+    () => {
+        const classes = useStyles();
+        const [value, setValue] = React.useState('');
+
+        let options = [];
+
+        let i = 0;
+        while (i < 10000) {
+            options.push(`${i}`);
+            i++;
+        }
+
+        const onChange = (event, value) => {
+            if (value) {
+                setValue(value);
+            } else {
+                setValue('');
+            }
+        };
+
+        return (
+            <div className={classes.container}>
+                <Select
+                    label='Virtualized Select'
+                    onChange={onChange}
+                    options={options}
+                    required
+                    selectedOption={value}
+                />
+            </div>
+        );
+    },
+    {
+        notes: { markdown: propsMarkdown },
+    }
+);

--- a/stories/utilities/props/select.md
+++ b/stories/utilities/props/select.md
@@ -3,10 +3,13 @@
 | value          | required | description                                                                  |
 | -------------- | -------- | ---------------------------------------------------------------------------- |
 | darkMode       | no       | boolean to indicate if styling should be inverted to be on a dark background |
+| error          | no       | boolean value to indicate if text field should denote errored                |
+| helperText     | no       | string value of helper text displayed below select                           |
 | label          | yes      | string label for the input                                                   |
 | options        | yes      | array of options                                                             |
 | color          | no       | theme color for the input                                                    |
 | renderOption   | no       | function used to render options in the dropdown                              |
+| required       | no       | boolean value to indicate if text field should denote required               |
 | selectedOption | no       | option that is currently selected                                            |
 
 Additional props will be passed to [@material-ui/lab/Autocomplete](https://material-ui.com/api/autocomplete/)

--- a/test/select/src/__snapshots__/select.spec.js.snap
+++ b/test/select/src/__snapshots__/select.spec.js.snap
@@ -289,3 +289,159 @@ exports[`Select should render with 10000 items 1`] = `
   </div>
 </div>
 `;
+
+exports[`Select should render with required 1`] = `
+<div
+  aria-expanded={false}
+  aria-owns={null}
+  className="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  onMouseDown={[Function]}
+  role="combobox"
+  style={
+    Object {
+      "width": "100%",
+    }
+  }
+>
+  <div
+    className="MuiFormControl-root MuiTextField-root makeStyles-input-21 MuiFormControl-fullWidth"
+  >
+    <label
+      className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense MuiInputLabel-outlined Mui-required Mui-required"
+      data-shrink={false}
+      htmlFor="select"
+      id="select-label"
+    >
+      test
+      <span
+        aria-hidden={true}
+        className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+      >
+         
+        *
+      </span>
+    </label>
+    <div
+      className="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+      onClick={[Function]}
+    >
+      <input
+        aria-activedescendant={null}
+        aria-autocomplete="list"
+        aria-controls={null}
+        aria-invalid={false}
+        autoCapitalize="none"
+        autoComplete="off"
+        autoFocus={false}
+        className="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input makeStyles-input-18 MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+        disabled={false}
+        id="select"
+        onAnimationStart={[Function]}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        required={true}
+        spellCheck="false"
+        type="text"
+        value=""
+      />
+      <div
+        className="MuiAutocomplete-endAdornment"
+      >
+        <button
+          aria-label="Clear"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator makeStyles-clearIndicator-17 MuiAutocomplete-clearIndicatorDirty"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={-1}
+          title="Clear"
+          type="button"
+        >
+          <span
+            className="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </span>
+          <span
+            className="MuiTouchRipple-root"
+          />
+        </button>
+        <button
+          aria-label="Open"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator makeStyles-popupIndicator-20"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={-1}
+          title="Open"
+          type="button"
+        >
+          <span
+            className="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </span>
+          <span
+            className="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+      <fieldset
+        aria-hidden={true}
+        className="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-22"
+      >
+        <legend
+          className="PrivateNotchedOutline-legendLabelled-9"
+        >
+          <span>
+            test
+             *
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+  </div>
+</div>
+`;

--- a/test/select/src/__snapshots__/select.spec.js.snap
+++ b/test/select/src/__snapshots__/select.spec.js.snap
@@ -138,6 +138,7 @@ exports[`Select should render empty 1`] = `
         </legend>
       </fieldset>
     </div>
+    
   </div>
 </div>
 `;
@@ -286,6 +287,305 @@ exports[`Select should render with 10000 items 1`] = `
         </legend>
       </fieldset>
     </div>
+    
+  </div>
+</div>
+`;
+
+exports[`Select should render with error 1`] = `
+<div
+  aria-expanded={false}
+  aria-owns={null}
+  className="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  onMouseDown={[Function]}
+  role="combobox"
+  style={
+    Object {
+      "width": "100%",
+    }
+  }
+>
+  <div
+    className="MuiFormControl-root MuiTextField-root makeStyles-input-27 MuiFormControl-fullWidth"
+  >
+    <label
+      className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense MuiInputLabel-outlined Mui-error Mui-error"
+      data-shrink={false}
+      htmlFor="select"
+      id="select-label"
+    >
+      test
+    </label>
+    <div
+      className="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot Mui-error Mui-error MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+      onClick={[Function]}
+    >
+      <input
+        aria-activedescendant={null}
+        aria-autocomplete="list"
+        aria-controls={null}
+        aria-invalid={true}
+        autoCapitalize="none"
+        autoComplete="off"
+        autoFocus={false}
+        className="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input makeStyles-input-24 MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+        disabled={false}
+        id="select"
+        onAnimationStart={[Function]}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        required={false}
+        spellCheck="false"
+        type="text"
+        value=""
+      />
+      <div
+        className="MuiAutocomplete-endAdornment"
+      >
+        <button
+          aria-label="Clear"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator makeStyles-clearIndicator-23 MuiAutocomplete-clearIndicatorDirty"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={-1}
+          title="Clear"
+          type="button"
+        >
+          <span
+            className="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </span>
+        </button>
+        <button
+          aria-label="Open"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator makeStyles-popupIndicator-26"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={-1}
+          title="Open"
+          type="button"
+        >
+          <span
+            className="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <fieldset
+        aria-hidden={true}
+        className="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-28"
+      >
+        <legend
+          className="PrivateNotchedOutline-legendLabelled-9"
+        >
+          <span>
+            test
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+    
+  </div>
+</div>
+`;
+
+exports[`Select should render with helper text 1`] = `
+<div
+  aria-expanded={false}
+  aria-owns={null}
+  className="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  onMouseDown={[Function]}
+  role="combobox"
+  style={
+    Object {
+      "width": "100%",
+    }
+  }
+>
+  <div
+    className="MuiFormControl-root MuiTextField-root makeStyles-input-33 MuiFormControl-fullWidth"
+  >
+    <label
+      className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense MuiInputLabel-outlined"
+      data-shrink={false}
+      htmlFor="select"
+      id="select-label"
+    >
+      test
+    </label>
+    <div
+      className="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+      onClick={[Function]}
+    >
+      <input
+        aria-activedescendant={null}
+        aria-autocomplete="list"
+        aria-controls={null}
+        aria-describedby="select-helper-text"
+        aria-invalid={false}
+        autoCapitalize="none"
+        autoComplete="off"
+        autoFocus={false}
+        className="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input makeStyles-input-30 MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+        disabled={false}
+        id="select"
+        onAnimationStart={[Function]}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        required={false}
+        spellCheck="false"
+        type="text"
+        value=""
+      />
+      <div
+        className="MuiAutocomplete-endAdornment"
+      >
+        <button
+          aria-label="Clear"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator makeStyles-clearIndicator-29 MuiAutocomplete-clearIndicatorDirty"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={-1}
+          title="Clear"
+          type="button"
+        >
+          <span
+            className="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </span>
+          <span
+            className="MuiTouchRipple-root"
+          />
+        </button>
+        <button
+          aria-label="Open"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator makeStyles-popupIndicator-32"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={-1}
+          title="Open"
+          type="button"
+        >
+          <span
+            className="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </span>
+          <span
+            className="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+      <fieldset
+        aria-hidden={true}
+        className="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-34"
+      >
+        <legend
+          className="PrivateNotchedOutline-legendLabelled-9"
+        >
+          <span>
+            test
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+    <p
+      className="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-marginDense"
+      id="select-helper-text"
+    >
+      some helper text
+    </p>
   </div>
 </div>
 `;
@@ -442,6 +742,7 @@ exports[`Select should render with required 1`] = `
         </legend>
       </fieldset>
     </div>
+    
   </div>
 </div>
 `;

--- a/test/select/src/select.spec.js
+++ b/test/select/src/select.spec.js
@@ -36,4 +36,18 @@ describe('Select', () => {
         // then
         expect(tree).toMatchSnapshot();
     });
+
+    it('should render with required', () => {
+        // given
+        const options = [];
+
+        // when
+        const component = renderer.create(
+            <Select label='test' onChange={() => {}} required selectedOption={''} options={options} />
+        );
+        const tree = component.toJSON();
+
+        // then
+        expect(tree).toMatchSnapshot();
+    });
 });

--- a/test/select/src/select.spec.js
+++ b/test/select/src/select.spec.js
@@ -50,4 +50,38 @@ describe('Select', () => {
         // then
         expect(tree).toMatchSnapshot();
     });
+
+    it('should render with error', () => {
+        // given
+        const options = [];
+
+        // when
+        const component = renderer.create(
+            <Select error label='test' onChange={() => {}} selectedOption={''} options={options} />
+        );
+        const tree = component.toJSON();
+
+        // then
+        expect(tree).toMatchSnapshot();
+    });
+
+    it('should render with helper text', () => {
+        // given
+        const options = [];
+
+        // when
+        const component = renderer.create(
+            <Select
+                helperText='some helper text'
+                label='test'
+                onChange={() => {}}
+                selectedOption={''}
+                options={options}
+            />
+        );
+        const tree = component.toJSON();
+
+        // then
+        expect(tree).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
## Description
### Feature
Pass required, error and help text to Material Text Field  for `@tractorzoom/select`

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] The test workflow is passing locally