### PR TITLE
feat: add optional header component to be rendered in side-panel

### DIFF
--- a/packages/side-panel/src/side-panel.js
+++ b/packages/side-panel/src/side-panel.js
@@ -29,7 +29,7 @@ const SidePanel = (props) => {
             >
                 <div className={classes.drawerHeader}>
                     {Boolean(props.headerComponent) && props.headerComponent}
-                    <IconButton onClick={() => setOpen(false)}>
+                    <IconButton className={classes.closeButton} onClick={() => setOpen(false)}>
                         <ChevronLeftIcon style={{ color: 'white' }} />
                     </IconButton>
                 </div>

--- a/packages/side-panel/src/side-panel.js
+++ b/packages/side-panel/src/side-panel.js
@@ -28,6 +28,7 @@ const SidePanel = (props) => {
                 }}
             >
                 <div className={classes.drawerHeader}>
+                    {Boolean(props.headerComponent) && props.headerComponent}
                     <IconButton onClick={() => setOpen(false)}>
                         <ChevronLeftIcon style={{ color: 'white' }} />
                     </IconButton>
@@ -50,6 +51,7 @@ const SidePanel = (props) => {
 
 SidePanel.propTypes = {
     children: PropTypes.any,
+    headerComponent: PropTypes.node,
     open: PropTypes.bool.isRequired,
     setOpen: PropTypes.func.isRequired,
 };

--- a/packages/side-panel/src/styles.js
+++ b/packages/side-panel/src/styles.js
@@ -10,6 +10,9 @@ const paper = {
 };
 
 const useStyles = makeStyles((theme) => ({
+    closeButton: {
+        marginLeft: 'auto',
+    },
     drawer: {
         width: paper.width,
         flexShrink: 0,

--- a/stories/side-panel/with-header-component.stories.js
+++ b/stories/side-panel/with-header-component.stories.js
@@ -1,0 +1,41 @@
+import SidePanel from '../../packages/side-panel/src';
+import React from 'react';
+import propsMarkdown from '../utilities/props/side-panel.md';
+import { makeStyles } from '@material-ui/core/styles';
+import { storiesOf } from '@storybook/react';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles({
+    container: {
+        padding: 20,
+    },
+    headerComponent: {
+        color: 'white',
+        marginRight: 'auto',
+    },
+});
+
+storiesOf('Side Panel', module).add(
+    'With header component',
+    () => {
+        const classes = useStyles();
+        const [open, setOpen] = React.useState(true);
+
+        return (
+            <div className={classes.container}>
+                <SidePanel
+                    headerComponent={<Typography className={classes.headerComponent}>Header Text</Typography>}
+                    open={open}
+                    setOpen={setOpen}
+                >
+                    <Typography>First Child</Typography>
+                    <Typography>Second Child</Typography>
+                    <Typography>Third Child</Typography>
+                </SidePanel>
+            </div>
+        );
+    },
+    {
+        notes: { markdown: propsMarkdown },
+    }
+);

--- a/stories/side-panel/with-header-component.stories.js
+++ b/stories/side-panel/with-header-component.stories.js
@@ -11,7 +11,6 @@ const useStyles = makeStyles({
     },
     headerComponent: {
         color: 'white',
-        marginRight: 'auto',
     },
 });
 

--- a/stories/utilities/props/side-panel.md
+++ b/stories/utilities/props/side-panel.md
@@ -1,7 +1,8 @@
-### Side Panel Props
+# Side Panel Props
 
-| value    | required | description                                                             |
-| -------- | -------- | ----------------------------------------------------------------------- |
-| open     | yes      | boolean value to determine whether the panel should be opened or closed |
-| setOpen  | yes      | setter function to change the value of `open`                           |
-| children | no       | child components of any type                                            |
+| value           | required | description                                                             |
+| --------------- | -------- | ----------------------------------------------------------------------- |
+| children        | no       | child components of any type                                            |
+| headerComponent | no       | optional node to be rendered next to close button in header             |
+| open            | yes      | boolean value to determine whether the panel should be opened or closed |
+| setOpen         | yes      | setter function to change the value of `open`                           |

--- a/test/side-panel/src/__snapshots__/side-panel.spec.js.snap
+++ b/test/side-panel/src/__snapshots__/side-panel.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Side Panel should render the side panel empty 1`] = `
+exports[`side panel should render the side panel empty 1`] = `
 Object {
   "debug": [Function],
   "findAllByAltText": [Function],
@@ -54,7 +54,61 @@ Object {
 }
 `;
 
-exports[`Side Panel should render the side panel with a child 1`] = `
+exports[`side panel should render the side panel with a child 1`] = `
+Object {
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+}
+`;
+
+exports[`side panel should render the side panel with a header component 1`] = `
 Object {
   "debug": [Function],
   "findAllByAltText": [Function],

--- a/test/side-panel/src/side-panel.spec.js
+++ b/test/side-panel/src/side-panel.spec.js
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import SidePanel from '../../../packages/side-panel/src';
 import React from 'react';
 
-describe('Side Panel', () => {
+describe('side panel', () => {
     it('should render the side panel empty', () => {
         // given
         const props = {
@@ -23,6 +23,23 @@ describe('Side Panel', () => {
         //given
         const props = {
             children: [<div>Child</div>],
+            open: true,
+            width: 'md',
+            setOpen: () => {},
+        };
+
+        //when
+        render(<SidePanel {...props} />);
+
+        //then
+        expect(screen).toMatchSnapshot();
+    });
+
+    it('should render the side panel with a header component', () => {
+        //given
+        const props = {
+            children: [<div>Child</div>],
+            headerComponent: <div>Header Component</div>,
             open: true,
             width: 'md',
             setOpen: () => {},


### PR DESCRIPTION
## Description
### Feature
Add optional header component that can be passed to `@tractorzoom/side-panel` to be rendered next to close button

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] The test workflow is passing locally