### PR TITLE
fix: add flex-shrink: 0 to fix UI issue in safari

### DIFF
--- a/packages/side-panel/src/styles.js
+++ b/packages/side-panel/src/styles.js
@@ -21,6 +21,7 @@ const useStyles = makeStyles((theme) => ({
         alignItems: 'center',
         background: '#6c757d',
         display: 'flex',
+        flexShrink: 0,
         padding: theme.spacing(0, 1),
         position: 'sticky',
         justifyContent: 'flex-end',


### PR DESCRIPTION
## Description

Adds `flex-shrink: 0;` to drawer header to stop shrinking on mobile safari 

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The test workflow is passing locally
