### PR TITLE
feat: add optional prop to be called on selection change

### DIFF
--- a/packages/button-dropdown/src/button-dropdown.js
+++ b/packages/button-dropdown/src/button-dropdown.js
@@ -26,6 +26,10 @@ const ButtonDropdown = (props) => {
     const handleMenuItemClick = (event, index) => {
         setSelectedIndex(index);
         setOpen(false);
+
+        if (props.onSelectionChange) {
+            props.onSelectionChange(props.options[selectedIndex]);
+        }
     };
 
     const handleToggle = () => {
@@ -114,6 +118,7 @@ ButtonDropdown.propTypes = {
     disabled: PropTypes.bool,
     label: PropTypes.string,
     onChange: PropTypes.func.isRequired,
+    onSelectionChange: PropTypes.func,
     options: PropTypes.arrayOf(PropTypes.string).isRequired,
     selectedOption: PropTypes.string,
 };

--- a/stories/utilities/props/button-dropdown.md
+++ b/stories/utilities/props/button-dropdown.md
@@ -1,11 +1,12 @@
 # Button Dropdown Props
 
-| value          | required | description                                                       |
-| -------------- | -------- | ----------------------------------------------------------------- |
-| className      | no       | string to pass to root button group component                     |
-| color          | no       | string to pass to button group color prop (defaults to `primary`) |
-| disabled       | no       | boolean to set buttons to disabled                                |
-| label          | no       | string to be rendered before selected option in first button      |
-| onChange       | yes      | function called on click of action button                         |
-| options        | yes      | array of string options to be rendered in dropdown                |
-| selectedOption | no       | string of selected option                                         |
+| value             | required | description                                                       |
+| ----------------- | -------- | ----------------------------------------------------------------- |
+| className         | no       | string to pass to root button group component                     |
+| color             | no       | string to pass to button group color prop (defaults to `primary`) |
+| disabled          | no       | boolean to set buttons to disabled                                |
+| label             | no       | string to be rendered before selected option in first button      |
+| onChange          | yes      | function called on click of action button                         |
+| onSelectionChange | no       | function called on change of selection                            |
+| options           | yes      | array of string options to be rendered in dropdown                |
+| selectedOption    | no       | string of selected option                                         |


### PR DESCRIPTION
## Description
### Feature
Add optional prop to `button-dropdown` for on selection change

for https://github.com/TractorZoom/iron-comps-client/issues/510

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] The test workflow is passing locally