### PR TITLE
feat: pass step to input props for text field

### DIFF
--- a/packages/text-field/src/text-field.js
+++ b/packages/text-field/src/text-field.js
@@ -5,8 +5,13 @@ import clsx from 'clsx';
 import useStyles from './styles';
 
 const TextField = (props) => {
-    const { className, darkMode, InputProps, margin, variant, ...otherProps } = props;
+    const { className, darkMode, InputProps, margin, step, variant, ...otherProps } = props;
     const classes = useStyles(darkMode)();
+    const inputPropsObj = { className: classes.inputValue };
+
+    if (otherProps.type === 'number') {
+        inputPropsObj.step = step;
+    }
 
     return (
         <MuiTextField
@@ -15,7 +20,7 @@ const TextField = (props) => {
             InputProps={{
                 ...InputProps,
                 classes: { notchedOutline: classes.inputBorder },
-                inputProps: { className: classes.inputValue },
+                inputProps: inputPropsObj,
             }}
             margin={margin}
             variant={variant}
@@ -29,6 +34,7 @@ TextField.defaultProps = {
     darkMode: false,
     InputProps: {},
     margin: 'dense',
+    step: 1,
     variant: 'outlined',
 };
 
@@ -37,6 +43,7 @@ TextField.propTypes = {
     darkMode: PropTypes.bool,
     InputProps: PropTypes.object,
     margin: PropTypes.string,
+    step: PropTypes.number,
     variant: PropTypes.string,
 };
 

--- a/stories/text-field/with-step.stories.js
+++ b/stories/text-field/with-step.stories.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import TextField from '../../packages/text-field/src';
+import propsMarkdown from '../utilities/props/text-field.md';
+import { storiesOf } from '@storybook/react';
+
+storiesOf('Text Field', module).add(
+    'With custom step',
+    () => {
+        const [value, setValue] = React.useState('');
+
+        const onChange = (event) => {
+            setValue(event.target.value);
+        };
+
+        return <TextField label='Text Field' onChange={onChange} step={1000} type='number' value={value} />;
+    },
+    {
+        notes: { markdown: propsMarkdown },
+    }
+);

--- a/stories/utilities/props/text-field.md
+++ b/stories/utilities/props/text-field.md
@@ -4,6 +4,7 @@
 | -------- | -------- | ---------------------------------------------------------------------------- |
 | darkMode | no       | boolean to indicate if styling should be inverted to be on a dark background |
 | margin   | no       | string for Material UI text field margin styling (defaults to `dense`)       |
+| step     | no       | number pass to input step with type of input is `number`                     |
 | variant  | no       | string for Material UI text field variant styling (defaults to `outlined`)   |
 
 Additional props will be passed to [Material UI TextField](https://material-ui.com/api/text-field/)

--- a/test/text-field/src/__snapshots__/text-field.spec.js.snap
+++ b/test/text-field/src/__snapshots__/text-field.spec.js.snap
@@ -30,6 +30,92 @@ exports[`text field should render when type is date 1`] = `
 </div>
 `;
 
+exports[`text field should render when type is number 1`] = `
+<div
+  className="MuiFormControl-root MuiTextField-root makeStyles-inputLabel-15 MuiFormControl-marginDense"
+>
+  <label
+    className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense MuiInputLabel-outlined"
+    data-shrink={false}
+  >
+    test
+  </label>
+  <div
+    className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+    onClick={[Function]}
+  >
+    <input
+      aria-invalid={false}
+      autoFocus={false}
+      className="MuiInputBase-input MuiOutlinedInput-input makeStyles-inputValue-16 MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+      disabled={false}
+      onAnimationStart={[Function]}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      required={false}
+      step={1}
+      type="number"
+    />
+    <fieldset
+      aria-hidden={true}
+      className="PrivateNotchedOutline-root-4 MuiOutlinedInput-notchedOutline makeStyles-inputBorder-14"
+    >
+      <legend
+        className="PrivateNotchedOutline-legendLabelled-6"
+      >
+        <span>
+          test
+        </span>
+      </legend>
+    </fieldset>
+  </div>
+</div>
+`;
+
+exports[`text field should render when type is number with custom step 1`] = `
+<div
+  className="MuiFormControl-root MuiTextField-root makeStyles-inputLabel-18 MuiFormControl-marginDense"
+>
+  <label
+    className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense MuiInputLabel-outlined"
+    data-shrink={false}
+  >
+    test
+  </label>
+  <div
+    className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+    onClick={[Function]}
+  >
+    <input
+      aria-invalid={false}
+      autoFocus={false}
+      className="MuiInputBase-input MuiOutlinedInput-input makeStyles-inputValue-19 MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+      disabled={false}
+      onAnimationStart={[Function]}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      required={false}
+      step={1000}
+      type="number"
+    />
+    <fieldset
+      aria-hidden={true}
+      className="PrivateNotchedOutline-root-4 MuiOutlinedInput-notchedOutline makeStyles-inputBorder-17"
+    >
+      <legend
+        className="PrivateNotchedOutline-legendLabelled-6"
+      >
+        <span>
+          test
+        </span>
+      </legend>
+    </fieldset>
+  </div>
+</div>
+`;
+
 exports[`text field should render with custom margin and variant 1`] = `
 <div
   className="MuiFormControl-root MuiTextField-root makeStyles-inputLabel-9 MuiFormControl-marginNormal"

--- a/test/text-field/src/text-field.spec.js
+++ b/test/text-field/src/text-field.spec.js
@@ -52,4 +52,37 @@ describe('text field', () => {
         // then
         expect(tree).toMatchSnapshot();
     });
+
+    it('should render when type is number', () => {
+        // given
+        const props = {
+            label: 'test',
+            onChange: jest.fn(),
+            type: 'number',
+        };
+
+        // when
+        const component = renderer.create(<TextField {...props} />);
+        const tree = component.toJSON();
+
+        // then
+        expect(tree).toMatchSnapshot();
+    });
+
+    it('should render when type is number with custom step', () => {
+        // given
+        const props = {
+            label: 'test',
+            onChange: jest.fn(),
+            step: 1000,
+            type: 'number',
+        };
+
+        // when
+        const component = renderer.create(<TextField {...props} />);
+        const tree = component.toJSON();
+
+        // then
+        expect(tree).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
## Description
### Feature
Add step prop to be passed to inputProps for text field component

for https://github.com/TractorZoom/iron-comps-client/issues/517

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] The test workflow is passing locally