### PR TITLE
chore: add abilty to pass dataCy attribute to select

### DIFF
--- a/packages/select/src/select.js
+++ b/packages/select/src/select.js
@@ -46,6 +46,7 @@ const Select = (props) => {
                             ...params.InputProps.classes,
                             notchedOutline: textFieldClasses.notchedOutline,
                         },
+                        'data-cy': props.dataCy,
                     }}
                     size='small'
                     variant='outlined'
@@ -66,6 +67,7 @@ Select.defaultProps = {
     darkMode: false,
     error: false,
     helperText: '',
+    dataCy: undefined,
     renderOption: (option) => <Typography noWrap>{option}</Typography>,
     required: false,
 };
@@ -75,6 +77,7 @@ Select.propTypes = {
     darkMode: PropTypes.bool,
     error: PropTypes.bool,
     helperText: PropTypes.string,
+    dataCy: PropTypes.string,
     label: PropTypes.string.isRequired,
     options: PropTypes.array.isRequired,
     renderOption: PropTypes.func,

--- a/stories/utilities/props/select.md
+++ b/stories/utilities/props/select.md
@@ -2,6 +2,7 @@
 
 | value          | required | description                                                                  |
 | -------------- | -------- | ---------------------------------------------------------------------------- |
+| dataCy         | no       | string added as the data-cy attribute on the input element                   |
 | darkMode       | no       | boolean to indicate if styling should be inverted to be on a dark background |
 | error          | no       | boolean value to indicate if text field should denote errored                |
 | helperText     | no       | string value of helper text displayed below select                           |


### PR DESCRIPTION
## Description

Adds a `dataCy` prop to pass down to the input of the autocomplete

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The test workflow is passing locally
