### PR TITLE
feat: use theme with dark mode for side panel

### DIFF
--- a/packages/side-panel/src/side-panel.js
+++ b/packages/side-panel/src/side-panel.js
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import Divider from '@material-ui/core/Divider';
 import Drawer from '@material-ui/core/Drawer';
@@ -6,6 +7,13 @@ import IconButton from '@material-ui/core/IconButton';
 import PropTypes from 'prop-types';
 import useStyles from './styles';
 import withWidth from '@material-ui/core/withWidth';
+
+const theme = createMuiTheme({
+    palette: {
+        type: 'dark',
+    },
+    spacing: 5,
+});
 
 const SidePanel = (props) => {
     const { open, setOpen } = props;
@@ -17,7 +25,7 @@ const SidePanel = (props) => {
     }, []);
 
     return (
-        <>
+        <ThemeProvider theme={theme}>
             <Drawer
                 className={isMobile ? classes.drawerMobile : classes.drawer}
                 anchor='left'
@@ -45,7 +53,7 @@ const SidePanel = (props) => {
                     return newChild;
                 })}
             </Drawer>
-        </>
+        </ThemeProvider>
     );
 };
 

--- a/packages/side-panel/src/styles.js
+++ b/packages/side-panel/src/styles.js
@@ -2,7 +2,6 @@ import { makeStyles } from '@material-ui/core/styles';
 
 const paper = {
     width: 300,
-    backgroundColor: '#6c757d',
     top: 'unset',
     borderRight: 'none',
     padding: 20,
@@ -19,7 +18,6 @@ const useStyles = makeStyles((theme) => ({
     },
     drawerHeader: {
         alignItems: 'center',
-        background: '#6c757d',
         display: 'flex',
         flexShrink: 0,
         padding: theme.spacing(0, 1),
@@ -38,19 +36,16 @@ const useStyles = makeStyles((theme) => ({
         width: '100vw',
     },
     headerDivider: {
-        backgroundColor: 'white',
         position: 'sticky',
         top: 48,
         zIndex: 999,
     },
     icon: {
-        color: 'white',
         display: 'block',
         margin: 'auto',
         marginLeft: 5,
     },
     toggleOpenButton: {
-        backgroundColor: '#6c757d',
         borderRadius: '0px 40px 40px 0px',
         display: 'flex',
         height: 50,

--- a/stories/side-panel/with-header-component.stories.js
+++ b/stories/side-panel/with-header-component.stories.js
@@ -9,9 +9,6 @@ const useStyles = makeStyles({
     container: {
         padding: 20,
     },
-    headerComponent: {
-        color: 'white',
-    },
 });
 
 storiesOf('Side Panel', module).add(
@@ -22,11 +19,7 @@ storiesOf('Side Panel', module).add(
 
         return (
             <div className={classes.container}>
-                <SidePanel
-                    headerComponent={<Typography className={classes.headerComponent}>Header Text</Typography>}
-                    open={open}
-                    setOpen={setOpen}
-                >
+                <SidePanel headerComponent={<Typography>Header Text</Typography>} open={open} setOpen={setOpen}>
                     <Typography>First Child</Typography>
                     <Typography>Second Child</Typography>
                     <Typography>Third Child</Typography>


### PR DESCRIPTION
## Description
### Feature
Use Material UI to accomplish dark mode for side panel component

for https://github.com/TractorZoom/iron-comps-client/issues/493

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] The test workflow is passing locally

## Screenshots/GIFs
![Screen Shot 2020-10-01 at 10 29 10 AM](https://user-images.githubusercontent.com/54541871/94830611-60ae0e80-03d1-11eb-93ca-a76f67d83fb5.png)
