### PR TITLE
fix: extend theme before applying dark theme to side panel

### DIFF
--- a/packages/side-panel/src/side-panel.js
+++ b/packages/side-panel/src/side-panel.js
@@ -8,11 +8,10 @@ import PropTypes from 'prop-types';
 import useStyles from './styles';
 import withWidth from '@material-ui/core/withWidth';
 
-const theme = createMuiTheme({
+const darkTheme = createMuiTheme({
     palette: {
         type: 'dark',
     },
-    spacing: 5,
 });
 
 const SidePanel = (props) => {
@@ -25,7 +24,20 @@ const SidePanel = (props) => {
     }, []);
 
     return (
-        <ThemeProvider theme={theme}>
+        <ThemeProvider
+            theme={(theme) =>
+                createMuiTheme({
+                    ...theme,
+                    palette: {
+                        ...theme.palette,
+                        background: darkTheme.palette.background,
+                        divider: darkTheme.palette.divider,
+                        text: darkTheme.palette.text,
+                        type: darkTheme.palette.type,
+                    },
+                })
+            }
+        >
             <Drawer
                 className={isMobile ? classes.drawerMobile : classes.drawer}
                 anchor='left'

--- a/stories/side-panel/with-header-component.stories.js
+++ b/stories/side-panel/with-header-component.stories.js
@@ -1,3 +1,4 @@
+import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import SidePanel from '../../packages/side-panel/src';
 import React from 'react';
 import propsMarkdown from '../utilities/props/side-panel.md';
@@ -10,6 +11,7 @@ const useStyles = makeStyles({
         padding: 20,
     },
 });
+const theme = createMuiTheme();
 
 storiesOf('Side Panel', module).add(
     'With header component',
@@ -18,13 +20,15 @@ storiesOf('Side Panel', module).add(
         const [open, setOpen] = React.useState(true);
 
         return (
-            <div className={classes.container}>
-                <SidePanel headerComponent={<Typography>Header Text</Typography>} open={open} setOpen={setOpen}>
-                    <Typography>First Child</Typography>
-                    <Typography>Second Child</Typography>
-                    <Typography>Third Child</Typography>
-                </SidePanel>
-            </div>
+            <ThemeProvider theme={theme}>
+                <div className={classes.container}>
+                    <SidePanel headerComponent={<Typography>Header Text</Typography>} open={open} setOpen={setOpen}>
+                        <Typography>First Child</Typography>
+                        <Typography>Second Child</Typography>
+                        <Typography>Third Child</Typography>
+                    </SidePanel>
+                </div>
+            </ThemeProvider>
         );
     },
     {

--- a/test/side-panel/src/side-panel.spec.js
+++ b/test/side-panel/src/side-panel.spec.js
@@ -1,10 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import SidePanel from '../../../packages/side-panel/src';
 import React from 'react';
+import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 
 describe('side panel', () => {
     it('should render the side panel empty', () => {
         // given
+        const theme = createMuiTheme();
         const props = {
             children: [],
             open: true,
@@ -13,7 +15,11 @@ describe('side panel', () => {
         };
 
         // when
-        render(<SidePanel {...props} />);
+        render(
+            <ThemeProvider theme={theme}>
+                <SidePanel {...props} />
+            </ThemeProvider>
+        );
 
         // then
         expect(screen).toMatchSnapshot();
@@ -21,6 +27,7 @@ describe('side panel', () => {
 
     it('should render the side panel with a child', () => {
         //given
+        const theme = createMuiTheme();
         const props = {
             children: [<div>Child</div>],
             open: true,
@@ -29,7 +36,11 @@ describe('side panel', () => {
         };
 
         //when
-        render(<SidePanel {...props} />);
+        render(
+            <ThemeProvider theme={theme}>
+                <SidePanel {...props} />
+            </ThemeProvider>
+        );
 
         //then
         expect(screen).toMatchSnapshot();
@@ -37,6 +48,7 @@ describe('side panel', () => {
 
     it('should render the side panel with a header component', () => {
         //given
+        const theme = createMuiTheme();
         const props = {
             children: [<div>Child</div>],
             headerComponent: <div>Header Component</div>,
@@ -46,7 +58,11 @@ describe('side panel', () => {
         };
 
         //when
-        render(<SidePanel {...props} />);
+        render(
+            <ThemeProvider theme={theme}>
+                <SidePanel {...props} />
+            </ThemeProvider>
+        );
 
         //then
         expect(screen).toMatchSnapshot();


### PR DESCRIPTION
## Description
### Fix
Extend current them and apply dark mode to side panel

for https://github.com/TractorZoom/iron-comps-client/issues/493

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] The test workflow is passing locally