### PR TITLE
fix: handle clearing of the select

### DIFF
--- a/packages/select/src/select.js
+++ b/packages/select/src/select.js
@@ -78,7 +78,7 @@ const Select = (props) => {
             value={selectedOption}
             {...otherProps}
             onChange={(event, newValue) => {
-                const newValueTitle = typeof newValue === 'string' ? newValue : newValue.label ? newValue.label : '';
+                const newValueTitle = typeof newValue === 'string' ? newValue : newValue?.label ? newValue.label : '';
 
                 if (newValueTitle.includes('+ Add')) {
                     props.onAddNew(newValueTitle.replace('+ Add ', ''));


### PR DESCRIPTION
## Description

When the select is cleared we should gracefully handle that situation

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The test workflow is passing locally
