### PR TITLE
fix: switch to lat and lon to standardize

### DIFF
--- a/packages/places-select/src/places-select.js
+++ b/packages/places-select/src/places-select.js
@@ -32,7 +32,7 @@ const PlacesSelect = (props) => {
             address = { fullAddress: val.description };
 
             const geocodedAddress = await getGeocode({ address: val.description });
-            const { lat, lng } = await getLatLng(geocodedAddress[0]);
+            const { lat, lng: lon } = await getLatLng(geocodedAddress[0]);
 
             geocodedAddress[0].address_components.forEach((component) => {
                 if (component.types.includes('street_number')) {
@@ -60,7 +60,7 @@ const PlacesSelect = (props) => {
                 }
             });
 
-            address = { ...address, address: `${address.streetNumber} ${address.street}`, lat, lng };
+            address = { ...address, address: `${address.streetNumber} ${address.street}`, lat, lon };
         }
 
         setAddress(address);


### PR DESCRIPTION
BREAKING CHANGE: `latitude`/`longitude` replaced in favor of `lat`/`lon`

## Description
### Fix
Standardize refering to `lat`/`lon`

for https://tractorzoom.atlassian.net/browse/TZ-2930?atlOrigin=eyJpIjoiMDBiOWE3MmExYWVkNGYyZWI2N2U0ZTM0ZDQ0MmU1M2QiLCJwIjoiaiJ9

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] The test workflow is passing locally