### PR TITLE
feat(select): add fuzzy matching

### DIFF
--- a/packages/select/package-lock.json
+++ b/packages/select/package-lock.json
@@ -12,6 +12,25 @@
                 "regenerator-runtime": "^0.13.4"
             }
         },
+        "match-sorter": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.2.0.tgz",
+            "integrity": "sha512-yhmUTR5q6JP/ssR1L1y083Wp+C+TdR8LhYTxWI4IRgEUr8IXJu2mE6L3SwryCgX95/5J7qZdEg0G091sOxr1FQ==",
+            "requires": {
+                "@babel/runtime": "^7.12.5",
+                "remove-accents": "0.4.2"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.12.13",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
+                    "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    }
+                }
+            }
+        },
         "memoize-one": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
@@ -30,6 +49,11 @@
             "version": "0.13.7",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
             "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        },
+        "remove-accents": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+            "integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
         }
     }
 }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -34,6 +34,7 @@
         "@material-ui/lab": "^4.0.0-alpha.56"
     },
     "dependencies": {
+        "match-sorter": "6.2.0",
         "react-window": "1.8.6"
     }
 }

--- a/packages/select/src/select.js
+++ b/packages/select/src/select.js
@@ -7,6 +7,20 @@ import Typography from '@material-ui/core/Typography';
 import { matchSorter } from 'match-sorter';
 import useStyles from './styles';
 
+const getObjectOptionLabel = (option) => option.label;
+const renderObjectOption = (option) => (
+    <Typography data-cy={option.label.toLowerCase().split(' ').join('-')} noWrap>
+        {option.label}
+    </Typography>
+);
+
+const getStringOptionLabel = (option) => option;
+const renderStringOption = (option) => (
+    <Typography data-cy={option.toLowerCase().split(' ').join('-')} noWrap>
+        {option}
+    </Typography>
+);
+
 const Select = (props) => {
     const {
         color,
@@ -24,12 +38,6 @@ const Select = (props) => {
 
     const hasStringOptions = options && typeof options[0] === 'string';
     const matchOptions = hasStringOptions ? undefined : { keys: props.filterKeys };
-
-    const getObjectOptionLabel = (option) => option.label;
-    const renderObjectOption = (option) => <Typography noWrap>{option.label}</Typography>;
-
-    const getStringOptionLabel = (option) => option;
-    const renderStringOption = (option) => <Typography noWrap>{option}</Typography>;
 
     const getOptionLabel = hasStringOptions ? getStringOptionLabel : getObjectOptionLabel;
     const defaultRenderOption = hasStringOptions ? renderStringOption : renderObjectOption;
@@ -101,7 +109,7 @@ Select.defaultProps = {
     hasAddNewOption: false,
     helperText: '',
     dataCy: undefined,
-    filterKeys: [],
+    filterKeys: ['label'],
     onAddNew: undefined,
     required: false,
 };

--- a/packages/select/src/styles.js
+++ b/packages/select/src/styles.js
@@ -1,27 +1,13 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = (darkMode) =>
-    makeStyles((theme) => ({
-        clearIndicator: darkMode ? { color: theme.palette.common.white } : {},
-        input: darkMode ? { color: theme.palette.common.white } : {},
-        listbox: {
-            boxSizing: 'border-box',
-            '& ul': {
-                padding: 0,
-                margin: 0,
-            },
+const useStyles = makeStyles(() => ({
+    listbox: {
+        boxSizing: 'border-box',
+        '& ul': {
+            padding: 0,
+            margin: 0,
         },
-        popupIndicator: darkMode ? { color: theme.palette.common.white } : {},
-    }));
-
-export const useTextFieldStyles = (darkMode) =>
-    makeStyles((theme) => ({
-        input: darkMode ? { '& label': { color: theme.palette.common.white } } : {},
-        notchedOutline: darkMode
-            ? {
-                  borderColor: theme.palette.common.white,
-              }
-            : {},
-    }));
+    },
+}));
 
 export default useStyles;

--- a/stories/select/add-new.stories.js
+++ b/stories/select/add-new.stories.js
@@ -6,7 +6,6 @@ import { storiesOf } from '@storybook/react';
 
 const useStyles = makeStyles({
     container: {
-        backgroundColor: '#6c757d',
         padding: 20,
     },
 });
@@ -36,7 +35,6 @@ storiesOf('Select', module).add(
         return (
             <div className={classes.container}>
                 <Select
-                    darkMode
                     label='Virtualized Select'
                     onChange={onChange}
                     onAddNew={(addNew) => console.log('on add new: ', addNew)}

--- a/stories/select/select-object-options.stories.js
+++ b/stories/select/select-object-options.stories.js
@@ -1,29 +1,23 @@
 import Select from '../../packages/select/src';
 import React from 'react';
+import chance from '@tractorzoom/chance-the-wrapper';
 import propsMarkdown from '../utilities/props/select.md';
 import { makeStyles } from '@material-ui/core/styles';
 import { storiesOf } from '@storybook/react';
 
 const useStyles = makeStyles({
     container: {
-        backgroundColor: '#6c757d',
         padding: 20,
     },
 });
 
+const options = chance.n(() => ({ label: chance.word() }), chance.d20());
+
 storiesOf('Select', module).add(
-    'With dark mode',
+    'With object options',
     () => {
         const classes = useStyles();
         const [value, setValue] = React.useState('');
-
-        let options = [];
-
-        let i = 0;
-        while (i < 10000) {
-            options.push(`${i}`);
-            i++;
-        }
 
         const onChange = (event, value) => {
             if (value) {
@@ -36,7 +30,7 @@ storiesOf('Select', module).add(
         return (
             <div className={classes.container}>
                 <Select
-                    darkMode
+                    filterKeys={['label']}
                     label='Virtualized Select'
                     onChange={onChange}
                     options={options}

--- a/stories/select/select.stories.js
+++ b/stories/select/select.stories.js
@@ -1,5 +1,6 @@
 import Select from '../../packages/select/src';
 import React from 'react';
+import chance from '@tractorzoom/chance-the-wrapper';
 import propsMarkdown from '../utilities/props/select.md';
 import { makeStyles } from '@material-ui/core/styles';
 import { storiesOf } from '@storybook/react';
@@ -10,19 +11,13 @@ const useStyles = makeStyles({
     },
 });
 
+const options = chance.n(chance.word, 10000);
+
 storiesOf('Select', module).add(
     'With 10000 options',
     () => {
         const classes = useStyles();
         const [value, setValue] = React.useState('');
-
-        let options = [];
-
-        let i = 0;
-        while (i < 10000) {
-            options.push(`${i}`);
-            i++;
-        }
 
         const onChange = (event, value) => {
             if (value) {

--- a/test/select/src/__snapshots__/select.spec.js.snap
+++ b/test/select/src/__snapshots__/select.spec.js.snap
@@ -5,7 +5,11 @@ exports[`Select should render empty 1`] = `
   aria-expanded={false}
   aria-owns={null}
   className="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-  filterKeys={Array []}
+  filterKeys={
+    Array [
+      "label",
+    ]
+  }
   hasAddNewOption={false}
   onClick={[Function]}
   onKeyDown={[Function]}
@@ -150,7 +154,11 @@ exports[`Select should render with 10000 items 1`] = `
   aria-expanded={false}
   aria-owns={null}
   className="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-  filterKeys={Array []}
+  filterKeys={
+    Array [
+      "label",
+    ]
+  }
   hasAddNewOption={false}
   onClick={[Function]}
   onKeyDown={[Function]}
@@ -301,7 +309,11 @@ exports[`Select should render with add new option 1`] = `
   aria-expanded={false}
   aria-owns={null}
   className="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-  filterKeys={Array []}
+  filterKeys={
+    Array [
+      "label",
+    ]
+  }
   hasAddNewOption={false}
   onAddNew={[Function]}
   onClick={[Function]}
@@ -447,7 +459,11 @@ exports[`Select should render with error 1`] = `
   aria-expanded={false}
   aria-owns={null}
   className="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-  filterKeys={Array []}
+  filterKeys={
+    Array [
+      "label",
+    ]
+  }
   hasAddNewOption={false}
   onClick={[Function]}
   onKeyDown={[Function]}
@@ -592,7 +608,11 @@ exports[`Select should render with helper text 1`] = `
   aria-expanded={false}
   aria-owns={null}
   className="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-  filterKeys={Array []}
+  filterKeys={
+    Array [
+      "label",
+    ]
+  }
   hasAddNewOption={false}
   onClick={[Function]}
   onKeyDown={[Function]}
@@ -749,7 +769,11 @@ exports[`Select should render with required 1`] = `
   aria-expanded={false}
   aria-owns={null}
   className="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-  filterKeys={Array []}
+  filterKeys={
+    Array [
+      "label",
+    ]
+  }
   hasAddNewOption={false}
   onClick={[Function]}
   onKeyDown={[Function]}

--- a/test/select/src/__snapshots__/select.spec.js.snap
+++ b/test/select/src/__snapshots__/select.spec.js.snap
@@ -5,6 +5,7 @@ exports[`Select should render empty 1`] = `
   aria-expanded={false}
   aria-owns={null}
   className="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+  filterKeys={Array []}
   hasAddNewOption={false}
   onClick={[Function]}
   onKeyDown={[Function]}
@@ -17,7 +18,7 @@ exports[`Select should render empty 1`] = `
   }
 >
   <div
-    className="MuiFormControl-root MuiTextField-root makeStyles-input-5 MuiFormControl-fullWidth"
+    className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense MuiInputLabel-outlined"
@@ -39,7 +40,7 @@ exports[`Select should render empty 1`] = `
         autoCapitalize="none"
         autoComplete="off"
         autoFocus={false}
-        className="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input makeStyles-input-2 MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+        className="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
         disabled={false}
         id="select"
         onAnimationStart={[Function]}
@@ -57,7 +58,7 @@ exports[`Select should render empty 1`] = `
       >
         <button
           aria-label="Clear"
-          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator makeStyles-clearIndicator-1 MuiAutocomplete-clearIndicatorDirty"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -92,7 +93,7 @@ exports[`Select should render empty 1`] = `
         </button>
         <button
           aria-label="Open"
-          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator makeStyles-popupIndicator-4"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -128,10 +129,10 @@ exports[`Select should render empty 1`] = `
       </div>
       <fieldset
         aria-hidden={true}
-        className="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-6"
+        className="PrivateNotchedOutline-root-2 MuiOutlinedInput-notchedOutline"
       >
         <legend
-          className="PrivateNotchedOutline-legendLabelled-9"
+          className="PrivateNotchedOutline-legendLabelled-4"
         >
           <span>
             test
@@ -149,6 +150,7 @@ exports[`Select should render with 10000 items 1`] = `
   aria-expanded={false}
   aria-owns={null}
   className="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+  filterKeys={Array []}
   hasAddNewOption={false}
   onClick={[Function]}
   onKeyDown={[Function]}
@@ -161,7 +163,7 @@ exports[`Select should render with 10000 items 1`] = `
   }
 >
   <div
-    className="MuiFormControl-root MuiTextField-root makeStyles-input-15 MuiFormControl-fullWidth"
+    className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-marginDense MuiInputLabel-outlined MuiFormLabel-filled"
@@ -183,7 +185,7 @@ exports[`Select should render with 10000 items 1`] = `
         autoCapitalize="none"
         autoComplete="off"
         autoFocus={false}
-        className="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input makeStyles-input-12 MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+        className="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
         disabled={false}
         id="select"
         onAnimationStart={[Function]}
@@ -201,7 +203,7 @@ exports[`Select should render with 10000 items 1`] = `
       >
         <button
           aria-label="Clear"
-          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator makeStyles-clearIndicator-11 MuiAutocomplete-clearIndicatorDirty"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -239,7 +241,7 @@ exports[`Select should render with 10000 items 1`] = `
         </button>
         <button
           aria-label="Open"
-          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator makeStyles-popupIndicator-14"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -278,10 +280,10 @@ exports[`Select should render with 10000 items 1`] = `
       </div>
       <fieldset
         aria-hidden={true}
-        className="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-16"
+        className="PrivateNotchedOutline-root-2 MuiOutlinedInput-notchedOutline"
       >
         <legend
-          className="PrivateNotchedOutline-legendLabelled-9 PrivateNotchedOutline-legendNotched-10"
+          className="PrivateNotchedOutline-legendLabelled-4 PrivateNotchedOutline-legendNotched-5"
         >
           <span>
             test
@@ -299,6 +301,7 @@ exports[`Select should render with add new option 1`] = `
   aria-expanded={false}
   aria-owns={null}
   className="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+  filterKeys={Array []}
   hasAddNewOption={false}
   onAddNew={[Function]}
   onClick={[Function]}
@@ -312,7 +315,7 @@ exports[`Select should render with add new option 1`] = `
   }
 >
   <div
-    className="MuiFormControl-root MuiTextField-root makeStyles-input-39 MuiFormControl-fullWidth"
+    className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense MuiInputLabel-outlined"
@@ -334,7 +337,7 @@ exports[`Select should render with add new option 1`] = `
         autoCapitalize="none"
         autoComplete="off"
         autoFocus={false}
-        className="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input makeStyles-input-36 MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+        className="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
         disabled={false}
         id="select"
         onAnimationStart={[Function]}
@@ -352,7 +355,7 @@ exports[`Select should render with add new option 1`] = `
       >
         <button
           aria-label="Clear"
-          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator makeStyles-clearIndicator-35 MuiAutocomplete-clearIndicatorDirty"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -387,7 +390,7 @@ exports[`Select should render with add new option 1`] = `
         </button>
         <button
           aria-label="Open"
-          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator makeStyles-popupIndicator-38"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -423,10 +426,10 @@ exports[`Select should render with add new option 1`] = `
       </div>
       <fieldset
         aria-hidden={true}
-        className="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-40"
+        className="PrivateNotchedOutline-root-2 MuiOutlinedInput-notchedOutline"
       >
         <legend
-          className="PrivateNotchedOutline-legendLabelled-9"
+          className="PrivateNotchedOutline-legendLabelled-4"
         >
           <span>
             test
@@ -444,6 +447,7 @@ exports[`Select should render with error 1`] = `
   aria-expanded={false}
   aria-owns={null}
   className="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+  filterKeys={Array []}
   hasAddNewOption={false}
   onClick={[Function]}
   onKeyDown={[Function]}
@@ -456,7 +460,7 @@ exports[`Select should render with error 1`] = `
   }
 >
   <div
-    className="MuiFormControl-root MuiTextField-root makeStyles-input-27 MuiFormControl-fullWidth"
+    className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense MuiInputLabel-outlined Mui-error Mui-error"
@@ -478,7 +482,7 @@ exports[`Select should render with error 1`] = `
         autoCapitalize="none"
         autoComplete="off"
         autoFocus={false}
-        className="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input makeStyles-input-24 MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+        className="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
         disabled={false}
         id="select"
         onAnimationStart={[Function]}
@@ -496,7 +500,7 @@ exports[`Select should render with error 1`] = `
       >
         <button
           aria-label="Clear"
-          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator makeStyles-clearIndicator-23 MuiAutocomplete-clearIndicatorDirty"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -531,7 +535,7 @@ exports[`Select should render with error 1`] = `
         </button>
         <button
           aria-label="Open"
-          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator makeStyles-popupIndicator-26"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -567,10 +571,10 @@ exports[`Select should render with error 1`] = `
       </div>
       <fieldset
         aria-hidden={true}
-        className="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-28"
+        className="PrivateNotchedOutline-root-2 MuiOutlinedInput-notchedOutline"
       >
         <legend
-          className="PrivateNotchedOutline-legendLabelled-9"
+          className="PrivateNotchedOutline-legendLabelled-4"
         >
           <span>
             test
@@ -588,6 +592,7 @@ exports[`Select should render with helper text 1`] = `
   aria-expanded={false}
   aria-owns={null}
   className="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+  filterKeys={Array []}
   hasAddNewOption={false}
   onClick={[Function]}
   onKeyDown={[Function]}
@@ -600,7 +605,7 @@ exports[`Select should render with helper text 1`] = `
   }
 >
   <div
-    className="MuiFormControl-root MuiTextField-root makeStyles-input-33 MuiFormControl-fullWidth"
+    className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense MuiInputLabel-outlined"
@@ -623,7 +628,7 @@ exports[`Select should render with helper text 1`] = `
         autoCapitalize="none"
         autoComplete="off"
         autoFocus={false}
-        className="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input makeStyles-input-30 MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+        className="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
         disabled={false}
         id="select"
         onAnimationStart={[Function]}
@@ -641,7 +646,7 @@ exports[`Select should render with helper text 1`] = `
       >
         <button
           aria-label="Clear"
-          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator makeStyles-clearIndicator-29 MuiAutocomplete-clearIndicatorDirty"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -679,7 +684,7 @@ exports[`Select should render with helper text 1`] = `
         </button>
         <button
           aria-label="Open"
-          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator makeStyles-popupIndicator-32"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -718,10 +723,10 @@ exports[`Select should render with helper text 1`] = `
       </div>
       <fieldset
         aria-hidden={true}
-        className="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-34"
+        className="PrivateNotchedOutline-root-2 MuiOutlinedInput-notchedOutline"
       >
         <legend
-          className="PrivateNotchedOutline-legendLabelled-9"
+          className="PrivateNotchedOutline-legendLabelled-4"
         >
           <span>
             test
@@ -744,6 +749,7 @@ exports[`Select should render with required 1`] = `
   aria-expanded={false}
   aria-owns={null}
   className="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+  filterKeys={Array []}
   hasAddNewOption={false}
   onClick={[Function]}
   onKeyDown={[Function]}
@@ -756,7 +762,7 @@ exports[`Select should render with required 1`] = `
   }
 >
   <div
-    className="MuiFormControl-root MuiTextField-root makeStyles-input-21 MuiFormControl-fullWidth"
+    className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense MuiInputLabel-outlined Mui-required Mui-required"
@@ -785,7 +791,7 @@ exports[`Select should render with required 1`] = `
         autoCapitalize="none"
         autoComplete="off"
         autoFocus={false}
-        className="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input makeStyles-input-18 MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+        className="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
         disabled={false}
         id="select"
         onAnimationStart={[Function]}
@@ -803,7 +809,7 @@ exports[`Select should render with required 1`] = `
       >
         <button
           aria-label="Clear"
-          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator makeStyles-clearIndicator-17 MuiAutocomplete-clearIndicatorDirty"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -841,7 +847,7 @@ exports[`Select should render with required 1`] = `
         </button>
         <button
           aria-label="Open"
-          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator makeStyles-popupIndicator-20"
+          className="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -880,10 +886,10 @@ exports[`Select should render with required 1`] = `
       </div>
       <fieldset
         aria-hidden={true}
-        className="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline makeStyles-notchedOutline-22"
+        className="PrivateNotchedOutline-root-2 MuiOutlinedInput-notchedOutline"
       >
         <legend
-          className="PrivateNotchedOutline-legendLabelled-9"
+          className="PrivateNotchedOutline-legendLabelled-4"
         >
           <span>
             test


### PR DESCRIPTION
add fuzzy matching to select component

BREAKING CHANGE: Fuzzy matching for select with object options now requires specifying filterKeys
prop

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] The test workflow is passing locally

## Screenshots/GIFs
![fuzzy matching in select](https://user-images.githubusercontent.com/54541871/108018936-b11fb480-6fde-11eb-8969-42292ea472c6.gif)
