### PR TITLE
feat: add custom header component and dialog sizes

### DIFF
--- a/packages/basic-dialog/src/dialog.js
+++ b/packages/basic-dialog/src/dialog.js
@@ -4,20 +4,21 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Typography } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import useStyles from './styles';
 
 const BasicDialog = (props) => {
-    const classes = useStyles();
+    const classes = useStyles(props.size);
     const isMobile = useMediaQuery('(max-width:600px)');
+    const containerClassName = props.size === 'small' ? classes.smallContainer : classes.largeContainer;
 
     return (
         <Dialog
             fullScreen={isMobile}
             open={props.isOpen}
             onClose={props.close}
-            PaperProps={{ className: classes.container, 'data-tour': props.dataTour }}
+            PaperProps={{ className: containerClassName, 'data-tour': props.dataTour }}
         >
             <DialogTitle className={classes.titleContainer} disableTypography>
                 <Typography variant='h5'>{props.title}</Typography>
@@ -32,6 +33,7 @@ BasicDialog.defaultProps = {
     actionButtons: [],
     dataTour: '',
     isOpen: false,
+    size: 'small',
 };
 
 BasicDialog.propTypes = {
@@ -40,6 +42,7 @@ BasicDialog.propTypes = {
     close: PropTypes.func.isRequired,
     dataTour: PropTypes.string,
     isOpen: PropTypes.bool,
+    size: PropTypes.oneOf(['small', 'large']).isRequired,
     title: PropTypes.string.isRequired,
 };
 

--- a/packages/basic-dialog/src/dialog.js
+++ b/packages/basic-dialog/src/dialog.js
@@ -20,9 +20,13 @@ const BasicDialog = (props) => {
             onClose={props.close}
             PaperProps={{ className: containerClassName, 'data-tour': props.dataTour }}
         >
-            <DialogTitle className={classes.titleContainer} disableTypography>
-                <Typography variant='h5'>{props.title}</Typography>
-            </DialogTitle>
+            {Boolean(props.headerComponent) ? (
+                props.headerComponent
+            ) : (
+                <DialogTitle className={classes.titleContainer} disableTypography>
+                    <Typography variant='h5'>{props.title}</Typography>
+                </DialogTitle>
+            )}
             <DialogContent className={classes.contentContainer}>{props.children || ''}</DialogContent>
             <DialogActions className={classes.footerContainer}>{props.actionButtons}</DialogActions>
         </Dialog>
@@ -41,9 +45,10 @@ BasicDialog.propTypes = {
     children: PropTypes.node,
     close: PropTypes.func.isRequired,
     dataTour: PropTypes.string,
+    headerComponent: PropTypes.node,
     isOpen: PropTypes.bool,
-    size: PropTypes.oneOf(['small', 'large']).isRequired,
-    title: PropTypes.string.isRequired,
+    size: PropTypes.oneOf(['small', 'large']),
+    title: PropTypes.string,
 };
 
 export default BasicDialog;

--- a/packages/basic-dialog/src/styles.js
+++ b/packages/basic-dialog/src/styles.js
@@ -1,11 +1,15 @@
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
-    container: {
-        minWidth: '50%',
-    },
     contentContainer: {
         padding: `0 ${theme.spacing(4)}px`,
+    },
+    largeContainer: {
+        minHeight: '80%',
+        minWidth: '80%',
+    },
+    smallContainer: {
+        minWidth: '50%',
     },
     titleContainer: {
         alignItems: 'center',

--- a/stories/basic-dialog/custom-header.stories.js
+++ b/stories/basic-dialog/custom-header.stories.js
@@ -1,0 +1,32 @@
+import BasicDialog from '../../packages/basic-dialog/src';
+import Button from '@material-ui/core/Button';
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+import propsMarkdown from '../utilities/props/basic-dialog.md';
+import { storiesOf } from '@storybook/react';
+
+storiesOf('Basic Dialog', module).add(
+    'Custom Header',
+    () => (
+        <BasicDialog
+            actionButtons={[
+                <Button onClick={() => {}} variant='contained'>
+                    Close
+                </Button>,
+            ]}
+            close={() => {}}
+            headerComponent={
+                <Typography style={{ background: 'blue', color: 'white', fontSize: 24, padding: 20 }}>
+                    This is my custom header
+                </Typography>
+            }
+            isOpen={true}
+            title='Dialog Title'
+        >
+            <Typography>Dialog content is passed in as children</Typography>
+        </BasicDialog>
+    ),
+    {
+        notes: { markdown: propsMarkdown },
+    }
+);

--- a/stories/basic-dialog/large-size.stories.js
+++ b/stories/basic-dialog/large-size.stories.js
@@ -1,0 +1,28 @@
+import BasicDialog from '../../packages/basic-dialog/src';
+import Button from '@material-ui/core/Button';
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+import propsMarkdown from '../utilities/props/basic-dialog.md';
+import { storiesOf } from '@storybook/react';
+
+storiesOf('Basic Dialog', module).add(
+    'Large Size',
+    () => (
+        <BasicDialog
+            actionButtons={[
+                <Button onClick={() => {}} variant='contained'>
+                    Close
+                </Button>,
+            ]}
+            close={() => {}}
+            isOpen={true}
+            size='large'
+            title='Dialog Title'
+        >
+            <Typography>Dialog content is passed in as children</Typography>
+        </BasicDialog>
+    ),
+    {
+        notes: { markdown: propsMarkdown },
+    }
+);

--- a/stories/utilities/props/basic-dialog.md
+++ b/stories/utilities/props/basic-dialog.md
@@ -1,9 +1,10 @@
 ### Basic Dialog Props
 
-| value         | required | description                                                               |
-| ------------- | -------- | ------------------------------------------------------------------------- |
-| actionButtons | no       | array of button nodes for footer                                          |
-| children      | no       | content to be rendered insitde dialog                                     |
-| close         | yes      | function called to request closing of dialog                              |
-| isOpen        | no       | boolean that determines if the dialog should be shown; defaults to `true` |
-| title         | yes      | string title of dialog                                                    |
+| value         | required | description                                                                            |
+| ------------- | -------- | -------------------------------------------------------------------------------------- |
+| actionButtons | no       | array of button nodes for footer                                                       |
+| children      | no       | content to be rendered inside dialog                                                   |
+| close         | yes      | function called to request closing of dialog                                           |
+| isOpen        | no       | boolean that determines if the dialog should be shown; defaults to `true`              |
+| size          | no       | string indicating size of dialog; options are `small` and `large`; defaults to `small` |
+| title         | yes      | string title of dialog                                                                 |

--- a/stories/utilities/props/basic-dialog.md
+++ b/stories/utilities/props/basic-dialog.md
@@ -1,10 +1,11 @@
 ### Basic Dialog Props
 
-| value         | required | description                                                                            |
-| ------------- | -------- | -------------------------------------------------------------------------------------- |
-| actionButtons | no       | array of button nodes for footer                                                       |
-| children      | no       | content to be rendered inside dialog                                                   |
-| close         | yes      | function called to request closing of dialog                                           |
-| isOpen        | no       | boolean that determines if the dialog should be shown; defaults to `true`              |
-| size          | no       | string indicating size of dialog; options are `small` and `large`; defaults to `small` |
-| title         | yes      | string title of dialog                                                                 |
+| value           | required | description                                                                            |
+| --------------- | -------- | -------------------------------------------------------------------------------------- |
+| actionButtons   | no       | array of button nodes for footer                                                       |
+| children        | no       | content to be rendered inside dialog                                                   |
+| close           | yes      | function called to request closing of dialog                                           |
+| headerComponent | no       | custom component to be rendered instead of `title`                                     |
+| isOpen          | no       | boolean that determines if the dialog should be shown; defaults to `true`              |
+| size            | no       | string indicating size of dialog; options are `small` and `large`; defaults to `small` |
+| title           | no       | string title of dialog; `headerComponent`, if specified, will be used instead of title |


### PR DESCRIPTION
## Description
### Feature
Add ability to specify a custom dialog header with `headerComponent` prop
Add `small` and `large` dialog sizes. Defaults to small to prevent a breaking change

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] The test workflow is passing locally

## Screenshots/GIFs
### Large size dialog
<img width="1666" alt="Screen Shot 2021-02-27 at 9 06 11 PM" src="https://user-images.githubusercontent.com/54541871/109406575-c6ca9d80-793f-11eb-82ff-718f8fb4379f.png">

### Custom header component
<img width="1680" alt="Screen Shot 2021-02-27 at 9 06 04 PM" src="https://user-images.githubusercontent.com/54541871/109406582-d4802300-793f-11eb-9f67-babc2d6f0026.png">
