### PR TITLE
feat: add custom iron comps theme package

### DIFF
--- a/packages/text-field/src/styles.js
+++ b/packages/text-field/src/styles.js
@@ -8,18 +8,22 @@ const useStyles = makeStyles((theme) => ({
         color: '#989898',
     },
     error: {
-        border: `1px solid ${theme.palette.error.main} !important`,
+        border: `2px solid ${theme.palette.error.main} !important`,
     },
     errorIcon: {
         color: theme.palette.error.main,
         margin: 12,
     },
     focused: {
-        border: `1px solid ${theme.palette.primary.main} !important`,
+        border: `2px solid ${theme.palette.primary.main} !important`,
     },
     input: {
-        border: `1px solid transparent`,
+        backgroundColor: 'rgba(0, 0, 0, 0.05) !important',
+        border: `2px solid transparent`,
         borderRadius: 8,
+        '&:hover': {
+            backgroundColor: 'rgba(0, 0, 0, 0.08) !important',
+        },
     },
     suffixLabel: {
         fontSize: '1.5rem',

--- a/packages/theme/.gitignore
+++ b/packages/theme/.gitignore
@@ -1,0 +1,2 @@
+/lib
+/node_modules

--- a/packages/theme/.npmrc
+++ b/packages/theme/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -1,0 +1,13 @@
+# @tractorzoom/theme
+
+Wrapper for Material UI's [TextField](https://material-ui.com/components/text-fields/#text-field)
+
+## Install
+
+```
+npm i --save @tractorzoom/theme
+```
+
+## Contributing
+
+We welcome improvements and fixes via PRs. Review the contributing guidelines in the repository readme for how to get started.

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -1,7 +1,5 @@
 # @tractorzoom/theme
 
-Wrapper for Material UI's [TextField](https://material-ui.com/components/text-fields/#text-field)
-
 ## Install
 
 ```

--- a/packages/theme/babel.config.js
+++ b/packages/theme/babel.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+    presets: [
+        [
+            '@babel/preset-env',
+            {
+                targets: {
+                    node: 'current',
+                },
+            },
+        ],
+        '@babel/preset-react',
+    ],
+};

--- a/packages/theme/package-lock.json
+++ b/packages/theme/package-lock.json
@@ -1,0 +1,13 @@
+{
+    "name": "@tractorzoom/theme",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@fontsource/inter": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-4.2.2.tgz",
+            "integrity": "sha512-lvR1PQe+8FTTd3YRW84KGcgUR8leZ7S3aY+51MQ90MQHI0VQe3cDH6T6jjs1qTm+wPmWfdSVjN8ugvNZpGUnvA=="
+        }
+    }
+}

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,0 +1,36 @@
+{
+    "name": "@tractorzoom/theme",
+    "version": "1.0.0",
+    "description": "Customized Material UI theme for Tractor Zoom",
+    "author": "@TractorZoom",
+    "license": "MIT",
+    "main": "lib/index.js",
+    "engines": {
+        "node": "12.x"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/TractorZoom/component-library.git"
+    },
+    "homepage": "https://github.com/TractorZoom/component-library/packages/theme/README.md",
+    "bugs": {
+        "url": "https://github.com/TractorZoom/component-library/issues"
+    },
+    "keywords": [
+        "material-ui",
+        "theme"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "../../node_modules/.bin/babel src --out-dir lib --copy-files",
+        "prepublish": "npm run build"
+    },
+    "peerDependencies": {
+        "@material-ui/core": "^4.10.2"
+    },
+    "dependencies": {
+        "@fontsource/inter": "4.2.2"
+    }
+}

--- a/packages/theme/src/index.js
+++ b/packages/theme/src/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    ironComps: require('./theme').default,
+};

--- a/packages/theme/src/theme.js
+++ b/packages/theme/src/theme.js
@@ -1,0 +1,36 @@
+import { createMuiTheme } from '@material-ui/core/styles';
+import '@fontsource/inter';
+
+const IC_BLACK = '#202020';
+
+const Theme = createMuiTheme({
+    palette: {
+        common: {
+            black: IC_BLACK,
+        },
+        error: {
+            main: '#c3134f',
+        },
+        primary: {
+            main: '#1f6df3',
+        },
+        secondary: {
+            main: '#0f223c',
+        },
+        success: {
+            main: '#008a1a',
+        },
+        text: {
+            primary: IC_BLACK,
+            secondary: '#818181',
+        },
+        contrastThreshold: 3,
+        tonalOffset: 0.2,
+    },
+    spacing: 4,
+    typography: {
+        fontFamily: ['Inter', 'Roboto', 'Helvetica', 'Arial', 'sans-serif'].join(','),
+    },
+});
+
+export default Theme;

--- a/packages/theme/src/theme.js
+++ b/packages/theme/src/theme.js
@@ -21,6 +21,7 @@ const Theme = createMuiTheme({
             main: '#008a1a',
         },
         text: {
+            disabled: 'rgba(0, 0, 0, 0.25)',
             primary: IC_BLACK,
             secondary: '#818181',
         },

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,26 +1,12 @@
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import React from 'react';
+import { ThemeProvider } from '@material-ui/core/styles';
+import { ironComps } from '../packages/theme/src/index';
 import '../styles.css';
-
-const theme = createMuiTheme({
-    palette: {
-        primary: {
-            main: '#0a6ef3',
-            dark: '#31435a',
-        },
-        secondary: {
-            main: '#f63c28',
-        },
-        contrastThreshold: 3,
-        tonalOffset: 0.2,
-    },
-    spacing: 5,
-});
 
 function App({ Component, pageProps }) {
     return (
-        <ThemeProvider theme={theme}>
+        <ThemeProvider theme={ironComps}>
             <CssBaseline />
             <Component {...pageProps} />
         </ThemeProvider>

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,6 +21,9 @@ export default () => {
             <Link href='/text-field'>
                 <Button variant='contained'>@tractorzoom/text-field</Button>
             </Link>
+            <Link href='/theme'>
+                <Button variant='contained'>@tractorzoom/theme</Button>
+            </Link>
         </div>
     );
 };

--- a/pages/theme.js
+++ b/pages/theme.js
@@ -1,0 +1,77 @@
+import { makeStyles, useTheme } from '@material-ui/core/styles';
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles((theme) => ({
+    container: {
+        alignItems: 'center',
+        display: 'flex',
+        flexDirection: 'column',
+        margin: 10,
+    },
+    swatch: {
+        border: `1px solid #00000019`,
+        borderRadius: 20,
+        height: 100,
+        width: 100,
+    },
+}));
+
+const ThemeExamples = () => {
+    const theme = useTheme();
+    const classes = useStyles();
+
+    const getSwatch = (color, title) => (
+        <div className={classes.container}>
+            <div className={classes.swatch} style={{ background: color }} />
+            <Typography>{title}</Typography>
+            <Typography>{color}</Typography>
+        </div>
+    );
+
+    return (
+        <div
+            style={{
+                margin: '40px auto',
+                maxWidth: 800,
+                display: 'flex',
+                flexDirection: 'column',
+            }}
+        >
+            <Typography style={{ textAlign: 'center' }} variant='h4'>
+                @tractorzoom/theme
+            </Typography>
+            <Typography style={{ marginTop: 40, textAlign: 'center' }} variant='h5'>
+                Iron Comps
+            </Typography>
+            <Typography style={{ marginTop: 40, textAlign: 'center' }} variant='h6'>
+                Colors
+            </Typography>
+            <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+                {getSwatch(theme.palette.primary.main, 'Primary')}
+                {getSwatch(theme.palette.secondary.main, 'Secondary')}
+                {getSwatch(theme.palette.error.main, 'Error')}
+                {getSwatch(theme.palette.success.main, 'Success')}
+                {getSwatch(theme.palette.common.white, 'White')}
+                {getSwatch(theme.palette.common.black, 'Black')}
+            </div>
+            <Typography style={{ marginTop: 40, textAlign: 'center' }} variant='h6'>
+                Backgrounds
+            </Typography>
+            <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+                {getSwatch(theme.palette.background.default, 'Default')}
+                {getSwatch(theme.palette.background.paper, 'Paper')}
+            </div>
+            <Typography style={{ marginTop: 40, textAlign: 'center' }} variant='h6'>
+                Text
+            </Typography>
+            <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+                {getSwatch(theme.palette.text.primary, 'Primary')}
+                {getSwatch(theme.palette.text.secondary, 'Secondary')}
+                {getSwatch(theme.palette.text.disabled, 'Disabled')}
+            </div>
+        </div>
+    );
+};
+
+export default ThemeExamples;


### PR DESCRIPTION
## Description
### Feature
Add theme package with `ironComps` theme

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] The test workflow is passing locally

## Screenshots/GIFs
### Design System documenting colors
<img width="1016" alt="Screen Shot 2021-03-24 at 5 55 13 PM" src="https://user-images.githubusercontent.com/54541871/112409937-5ae21780-8ce8-11eb-9869-ee7a39ac6453.png">

### Theme Examples
![Screen Shot 2021-03-25 at 3 29 54 PM](https://user-images.githubusercontent.com/54541871/112539490-0fc71380-8d7f-11eb-9cc9-3cffe7d13fea.png)
