### PR TITLE
feat: add ability to pass options to text field component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5014,6 +5014,15 @@
                 "chance": "1.1.7"
             }
         },
+        "@tractorzoom/simple-select": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@tractorzoom/simple-select/-/simple-select-1.1.0.tgz",
+            "integrity": "sha512-mToC/tWnWpL6Yb5bzzxewDwd7qE/obu9d64/NT7Ci7JlmL0Gqpcz3N67IoWxeHJ71syirKj1ORK1vOiwyl9BIA==",
+            "dev": true,
+            "requires": {
+                "clsx": "1.1.1"
+            }
+        },
         "@types/aria-query": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "@testing-library/react": "11.2.5",
         "@tractorzoom/button": "0.3.0",
         "@tractorzoom/chance-the-wrapper": "2.1.68",
+        "@tractorzoom/simple-select": "1.1.0",
         "babel-jest": "26.6.3",
         "babel-loader": "8.2.2",
         "commitizen": "4.2.3",

--- a/packages/simple-select/src/hook.js
+++ b/packages/simple-select/src/hook.js
@@ -27,9 +27,11 @@ const useSimpleSelect = (props) => {
         ...InputLabelProps,
         className: InputLabelProps.className ? clsx(labelClassName, InputLabelProps.className) : labelClassName,
     };
+    const selectPropsClasses = SelectProps.classes ? SelectProps.classes : {};
     const selectPropsObj = {
         ...SelectProps,
         classes: {
+            ...selectPropsClasses,
             icon: classes.chevronIcon,
         },
         IconComponent: KeyboardArrowDownIcon,

--- a/packages/text-field/README.md
+++ b/packages/text-field/README.md
@@ -12,11 +12,14 @@ npm i --save @tractorzoom/text-field
 
 ### Text Field Props
 
-| value       | required | description                                                                |
-| ----------- | -------- | -------------------------------------------------------------------------- |
-| step        | no       | number pass to input step with type of input is `number`                   |
-| suffixLabel | no       | string to be added as suffix inside input                                  |
-| variant     | no       | string for Material UI text field variant styling (defaults to `outlined`) |
+| value          | required | description                                                                                 |
+| -------------- | -------- | ------------------------------------------------------------------------------------------- |
+| step           | no       | number pass to input step with type of input is `number`                                    |
+| suffixLabel    | no       | string to be added as suffix inside input                                                   |
+| suffixOnChange | no       | function to handle on change of suffix options (required when `suffixOptions` are provided) |
+| suffixOptions  | no       | array of strings or object options to appear at end input                                   |
+| suffixValue    | no       | string or object option that is selected (required when `suffixOptions` are provided)       |
+| variant        | no       | string for Material UI text field variant styling (defaults to `outlined`)                  |
 
 Additional props will be passed to [Material UI TextField](https://material-ui.com/api/text-field/)
 

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -29,7 +29,8 @@
         "prepublish": "npm run build"
     },
     "peerDependencies": {
-        "@material-ui/core": "^4.10.2"
+        "@material-ui/core": "^4.10.2",
+        "@tractorzoom/simple-select": "^1.1.0"
     },
     "dependencies": {
         "clsx": "^1.1.1"

--- a/packages/text-field/src/hook.js
+++ b/packages/text-field/src/hook.js
@@ -8,7 +8,16 @@ import useStyles from './styles';
 
 const useTextField = (props) => {
     const classes = useStyles();
-    const { InputLabelProps, InputProps, step, suffixLabel, ...otherProps } = props;
+    const {
+        InputLabelProps,
+        InputProps,
+        step,
+        suffixLabel,
+        suffixOnChange,
+        suffixOptions,
+        suffixValue,
+        ...otherProps
+    } = props;
     const labelClassName = otherProps.value && !otherProps.error ? classes.activeLabel : '';
     const inputLabelPropsObj = {
         ...InputLabelProps,
@@ -51,7 +60,10 @@ const useTextField = (props) => {
 
     const updatedInputProps = {
         ...InputProps,
-        className: InputProps.className ? clsx(classes.input, InputProps.className) : classes.input,
+        className: clsx(classes.input, {
+            [classes.optionsInput]: suffixOptions.length,
+            [InputProps.className]: Boolean(InputProps.className),
+        }),
         classes: {
             adornedEnd: classes.adornedEnd,
             error: classes.error,
@@ -64,8 +76,20 @@ const useTextField = (props) => {
 
     return {
         ...otherProps,
+        className: clsx({
+            [classes.optionsTextField]: suffixOptions.length,
+            [otherProps.className]: Boolean(otherProps.className),
+        }),
         InputLabelProps: inputLabelPropsObj,
         InputProps: updatedInputProps,
+        optionsSelectProps: {
+            className: classes.optionsSelect,
+            SelectProps: { classes: { select: classes.optionsSelectLabel } },
+            InputProps: { className: classes.optionsSelectInput },
+            options: suffixOptions,
+            onChange: suffixOnChange,
+            value: suffixValue,
+        },
     };
 };
 

--- a/packages/text-field/src/styles.js
+++ b/packages/text-field/src/styles.js
@@ -28,6 +28,24 @@ const useStyles = makeStyles((theme) => ({
             backgroundColor: 'rgba(0, 0, 0, 0.08) !important',
         },
     },
+    optionsSelect: {
+        width: 74,
+    },
+    optionsInput: {
+        borderBottomRightRadius: 0,
+        borderTopRightRadius: 0,
+    },
+    optionsSelectInput: {
+        borderBottomLeftRadius: 0,
+        borderTopLeftRadius: 0,
+    },
+    optionsSelectLabel: {
+        fontSize: 12,
+        padding: `19px 12px 18px`,
+    },
+    optionsTextField: {
+        flexGrow: 1,
+    },
     suffixLabel: {
         fontSize: '1.5rem',
         margin: 18,

--- a/packages/text-field/src/text-field.js
+++ b/packages/text-field/src/text-field.js
@@ -1,12 +1,20 @@
 import MuiTextField from '@material-ui/core/TextField';
 import PropTypes from 'prop-types';
 import React from 'react';
+import SimpleSelect from '@tractorzoom/simple-select';
 import useTextField from './hook';
 
 const TextField = (props) => {
-    const textFieldProps = useTextField(props);
+    const { optionsSelectProps, style, ...textFieldProps } = useTextField(props);
 
-    return <MuiTextField {...textFieldProps} />;
+    return optionsSelectProps.options.length ? (
+        <div style={{ display: 'flex', ...style }}>
+            <MuiTextField {...textFieldProps} />
+            <SimpleSelect {...optionsSelectProps} />
+        </div>
+    ) : (
+        <MuiTextField style={style} {...textFieldProps} />
+    );
 };
 
 TextField.defaultProps = {
@@ -14,6 +22,9 @@ TextField.defaultProps = {
     InputProps: {},
     step: 1,
     suffixLabel: '',
+    suffixOptions: [],
+    suffixOnChange: () => {},
+    suffixValue: null,
     variant: 'filled',
 };
 
@@ -22,6 +33,9 @@ TextField.propTypes = {
     InputProps: PropTypes.object,
     step: PropTypes.number,
     suffixLabel: PropTypes.string,
+    suffixOptions: PropTypes.array,
+    suffixOnChange: PropTypes.func,
+    suffixValue: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     variant: PropTypes.string,
 };
 

--- a/pages/simple-select.js
+++ b/pages/simple-select.js
@@ -1,12 +1,33 @@
 import React, { useState } from 'react';
 import SimpleSelect from '../packages/simple-select/src/index';
+import TextField from '../packages/text-field/src/text-field';
 import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+    optionsSelect: {
+        maxWidth: 60,
+    },
+    optionsInput: {
+        borderBottomRightRadius: 0,
+        borderTopRightRadius: 0,
+    },
+    optionsSelectInput: {
+        borderBottomLeftRadius: 0,
+        borderTopLeftRadius: 0,
+    },
+    optionsSelectLabel: {
+        padding: `19px 12px 18px`,
+    },
+}));
 
 const SimpleSelectExamples = () => {
-    const [withStringOptionsValue, setWithStringOptionsValue] = useState('');
-    const stringOptions = ['hello', 'world', 'mario'];
+    const classes = useStyles();
+    const [withStringOptionsValue, setWithStringOptionsValue] = useState('ft');
+    const stringOptions = ['ft', 'in'];
 
     const [withObjectOptionsValue, setWithObjectOptionsValue] = useState('');
+    const [inputValue, setInputValue] = useState('');
     const objectOptions = [
         { value: '1', label: 'Tractor' },
         { value: '2', label: 'Zoom' },
@@ -36,6 +57,23 @@ const SimpleSelectExamples = () => {
                 style={{ marginTop: 20 }}
                 value={withStringOptionsValue}
             />
+            <div style={{ marginTop: 20 }}>
+                <TextField
+                    helperText='Enabled'
+                    label='Input Label'
+                    InputProps={{ className: classes.optionsInput }}
+                    onChange={onChange(setInputValue)}
+                    value={inputValue}
+                ></TextField>
+                <SimpleSelect
+                    className={classes.optionsSelect}
+                    SelectProps={{ classes: { select: classes.optionsSelectLabel } }}
+                    InputProps={{ className: classes.optionsSelectInput }}
+                    options={stringOptions}
+                    onChange={onChange(setWithStringOptionsValue)}
+                    value={withStringOptionsValue}
+                />
+            </div>
             <SimpleSelect
                 disabled
                 helperText='Disabled'

--- a/pages/simple-select.js
+++ b/pages/simple-select.js
@@ -1,33 +1,12 @@
 import React, { useState } from 'react';
 import SimpleSelect from '../packages/simple-select/src/index';
-import TextField from '../packages/text-field/src/text-field';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
-
-const useStyles = makeStyles((theme) => ({
-    optionsSelect: {
-        maxWidth: 60,
-    },
-    optionsInput: {
-        borderBottomRightRadius: 0,
-        borderTopRightRadius: 0,
-    },
-    optionsSelectInput: {
-        borderBottomLeftRadius: 0,
-        borderTopLeftRadius: 0,
-    },
-    optionsSelectLabel: {
-        padding: `19px 12px 18px`,
-    },
-}));
 
 const SimpleSelectExamples = () => {
-    const classes = useStyles();
-    const [withStringOptionsValue, setWithStringOptionsValue] = useState('ft');
+    const [withStringOptionsValue, setWithStringOptionsValue] = useState('');
     const stringOptions = ['ft', 'in'];
 
     const [withObjectOptionsValue, setWithObjectOptionsValue] = useState('');
-    const [inputValue, setInputValue] = useState('');
     const objectOptions = [
         { value: '1', label: 'Tractor' },
         { value: '2', label: 'Zoom' },
@@ -57,23 +36,6 @@ const SimpleSelectExamples = () => {
                 style={{ marginTop: 20 }}
                 value={withStringOptionsValue}
             />
-            <div style={{ marginTop: 20 }}>
-                <TextField
-                    helperText='Enabled'
-                    label='Input Label'
-                    InputProps={{ className: classes.optionsInput }}
-                    onChange={onChange(setInputValue)}
-                    value={inputValue}
-                ></TextField>
-                <SimpleSelect
-                    className={classes.optionsSelect}
-                    SelectProps={{ classes: { select: classes.optionsSelectLabel } }}
-                    InputProps={{ className: classes.optionsSelectInput }}
-                    options={stringOptions}
-                    onChange={onChange(setWithStringOptionsValue)}
-                    value={withStringOptionsValue}
-                />
-            </div>
             <SimpleSelect
                 disabled
                 helperText='Disabled'

--- a/pages/text-field.js
+++ b/pages/text-field.js
@@ -5,6 +5,8 @@ import Typography from '@material-ui/core/Typography';
 const TextFieldExamples = () => {
     const [withLabelValue, setWithLabelValue] = useState('');
     const [withCustomStepValue, setWithCustomStepValue] = useState(null);
+    const [withOptionsValue, setWithOptionsValue] = useState(null);
+    const [selectedOption, setSelectedOption] = useState(null);
     const [withEndAdornmentValue, setWithEndAdornmentValue] = useState(null);
     const [withErrorEndAdornmentValue, setWithErrorEndAdornmentValue] = useState(null);
 
@@ -55,6 +57,17 @@ const TextFieldExamples = () => {
                 style={{ marginTop: 20 }}
                 type='number'
                 value={withCustomStepValue}
+            />
+            <TextField
+                helperText='Number input with options'
+                label='Input Label'
+                onChange={onChange(setWithOptionsValue)}
+                style={{ marginTop: 20 }}
+                suffixOnChange={onChange(setSelectedOption)}
+                suffixOptions={['GAL', 'T']}
+                suffixValue={selectedOption}
+                type='number'
+                value={withOptionsValue}
             />
             <TextField
                 helperText='Custom end adornment'

--- a/pages/text-field.js
+++ b/pages/text-field.js
@@ -6,7 +6,7 @@ const TextFieldExamples = () => {
     const [withLabelValue, setWithLabelValue] = useState('');
     const [withCustomStepValue, setWithCustomStepValue] = useState(null);
     const [withOptionsValue, setWithOptionsValue] = useState(null);
-    const [selectedOption, setSelectedOption] = useState(null);
+    const [selectedOption, setSelectedOption] = useState('GAL');
     const [withEndAdornmentValue, setWithEndAdornmentValue] = useState(null);
     const [withErrorEndAdornmentValue, setWithErrorEndAdornmentValue] = useState(null);
 


### PR DESCRIPTION
## Add example for using input options field

Adds Feature or Fixes: TZ-3305

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The test workflow is passing locally

## Screenshots/GIFs
![Screen Shot 2021-04-01 at 3 53 53 PM](https://user-images.githubusercontent.com/80704623/113352904-85445e00-9302-11eb-819a-0c7b01164e98.png)

