### PR TITLE
Feat tz 3475 click target only on circle

### DIFF
--- a/packages/equipment-card/src/equipment-card.js
+++ b/packages/equipment-card/src/equipment-card.js
@@ -22,9 +22,9 @@ const EquipmentCard = (props) => {
     const isSelected = props.selectedEquipmentSet.has(props.id);
     const variableDetail = getVariableDetail(props);
     const variableDetailStyle = variableDetail.length >= 18 ? { fontSize: 14 } : {};
-    const circleSelectable = !props.handleEquipmentSelected ? { visibility: 'hidden' } : { 'pointer-events': 'all' };
-    !props.handleOpen ? (props.style['pointer-events'] = 'none') : '';
-
+    if (!props.handleOpen) {
+        props.style['pointer-events'] = 'none';
+    }
     const handleToggleSelected = (event) => {
         props.handleEquipmentSelected();
         event.stopPropagation();
@@ -94,18 +94,19 @@ const EquipmentCard = (props) => {
                         </div>
                     </CardContent>
                 </CardActionArea>
-                <IconButton
-                    aria-label='select equipment'
-                    className={isSelected ? classes.checkedButton : classes.selectButton}
-                    color='primary'
-                    data-cy='equipment-card-toggle-selection-button'
-                    data-tour={props.shouldHaveDataTour ? 'equipment-card-select-equipment' : ''}
-                    onClick={handleToggleSelected}
-                    style={circleSelectable}
-                    title={isSelected ? 'Remove from custom average' : 'Add to custom average'}
-                >
-                    {isSelected ? <CheckRoundedIcon fontSize='large' /> : <AddRoundedIcon fontSize='large' />}
-                </IconButton>
+                {!!props.handleEquipmentSelected && (
+                    <IconButton
+                        aria-label='select equipment'
+                        className={isSelected ? classes.checkedButton : classes.selectButton}
+                        color='primary'
+                        data-cy='equipment-card-toggle-selection-button'
+                        data-tour={props.shouldHaveDataTour ? 'equipment-card-select-equipment' : ''}
+                        onClick={handleToggleSelected}
+                        title={isSelected ? 'Remove from custom average' : 'Add to custom average'}
+                    >
+                        {isSelected ? <CheckRoundedIcon fontSize='large' /> : <AddRoundedIcon fontSize='large' />}
+                    </IconButton>
+                )}
             </Card>
         </div>
     );

--- a/packages/equipment-card/src/equipment-card.js
+++ b/packages/equipment-card/src/equipment-card.js
@@ -22,6 +22,8 @@ const EquipmentCard = (props) => {
     const isSelected = props.selectedEquipmentSet.has(props.id);
     const variableDetail = getVariableDetail(props);
     const variableDetailStyle = variableDetail.length >= 18 ? { fontSize: 14 } : {};
+    const circleSelectable = !props.handleEquipmentSelected ? { visibility: 'hidden' } : { 'pointer-events': 'all' };
+    !props.handleOpen ? (props.style['pointer-events'] = 'none') : '';
 
     const handleToggleSelected = (event) => {
         props.handleEquipmentSelected();
@@ -99,6 +101,7 @@ const EquipmentCard = (props) => {
                     data-cy='equipment-card-toggle-selection-button'
                     data-tour={props.shouldHaveDataTour ? 'equipment-card-select-equipment' : ''}
                     onClick={handleToggleSelected}
+                    style={circleSelectable}
                     title={isSelected ? 'Remove from custom average' : 'Add to custom average'}
                 >
                     {isSelected ? <CheckRoundedIcon fontSize='large' /> : <AddRoundedIcon fontSize='large' />}
@@ -120,8 +123,8 @@ EquipmentCard.defaultProps = {
 EquipmentCard.propTypes = {
     auctionDate: PropTypes.string,
     distance: PropTypes.number,
-    handleOpen: PropTypes.func.isRequired,
-    handleEquipmentSelected: PropTypes.func.isRequired,
+    handleOpen: PropTypes.func,
+    handleEquipmentSelected: PropTypes.func,
     id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
     imageUrl: PropTypes.string.isRequired,
     make: PropTypes.string.isRequired,

--- a/packages/equipment-card/src/styles.js
+++ b/packages/equipment-card/src/styles.js
@@ -22,6 +22,7 @@ export default makeStyles((theme) => ({
         },
         backgroundColor: theme.palette.success.main,
         color: theme.palette.common.white,
+        'pointer-events': 'all',
     },
     details: {
         alignItems: 'center',
@@ -69,6 +70,7 @@ export default makeStyles((theme) => ({
         },
         backgroundColor: theme.palette.common.white,
         border: '2px solid rgba(0, 0, 0, 0.12)',
+        'pointer-events': 'all',
     },
     selectedCard: {
         border: `3px solid ${theme.palette.success.main}`,

--- a/pages/equipment-card.js
+++ b/pages/equipment-card.js
@@ -204,7 +204,7 @@ const EquipmentCardExamples = () => {
                 {LIST_OF_EQUIPMENT.map((equipment) => (
                     <EquipmentCard
                         handleEquipmentSelected={handleEquipmentSelected(equipment)}
-                        handleOpen={handleOpen(equipment)}
+                        handleOpen={null}
                         key={equipment.id}
                         selectedEquipmentSet={selectedEquipmentSet}
                         style={{ margin: 5, maxWidth: 300 }}

--- a/pages/equipment-card.js
+++ b/pages/equipment-card.js
@@ -204,7 +204,7 @@ const EquipmentCardExamples = () => {
                 {LIST_OF_EQUIPMENT.map((equipment) => (
                     <EquipmentCard
                         handleEquipmentSelected={handleEquipmentSelected(equipment)}
-                        handleOpen={null}
+                        handleOpen={handleOpen(equipment)}
                         key={equipment.id}
                         selectedEquipmentSet={selectedEquipmentSet}
                         style={{ margin: 5, maxWidth: 300 }}


### PR DESCRIPTION
## Description

Please include a summary of the change and/or issue that is being worked on. Please also include relevant motivation and context. List any dependencies that are required for this change.

Adds Feature or Fixes: # (issue)

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The test workflow is passing locally

## Screenshots/GIFs
no onclick function for both small circle and card
![neither working](https://user-images.githubusercontent.com/59127090/118538694-24d37980-b714-11eb-96fe-7cf4bd299f25.gif)
card has functionality only
![only card open](https://user-images.githubusercontent.com/59127090/118538662-1b4a1180-b714-11eb-8af1-a34f419bdeaa.gif)
only the select button has functionality
![only card select](https://user-images.githubusercontent.com/59127090/118538639-14230380-b714-11eb-8801-40e16dac2ac2.gif)
functions for both
![both working](https://user-images.githubusercontent.com/59127090/118538395-bc849800-b713-11eb-80da-36074df41866.gif)